### PR TITLE
fix: add missing cmd/duplicacy-backup source dir and CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,95 @@
+name: Build Synology Binaries
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            goarm: ''
+            suffix: linux-amd64
+          - goos: linux
+            goarch: arm64
+            goarm: ''
+            suffix: linux-arm64
+          - goos: linux
+            goarch: arm
+            goarm: '7'
+            suffix: linux-armv7
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history so git describe works for version tags
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        if: matrix.suffix == 'linux-amd64'   # tests only need to run once
+        run: go test -v -race ./...
+
+      - name: Build binary (${{ matrix.suffix }})
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          GOARM: ${{ matrix.goarm }}
+          CGO_ENABLED: '0'
+        run: |
+          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+          BUILD_TIME=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+          LDFLAGS="-s -w -X main.version=${VERSION} -X main.buildTime=${BUILD_TIME}"
+          SUFFIX="${{ matrix.suffix }}"
+
+          mkdir -p build
+          go build -ldflags "${LDFLAGS}" \
+            -o "build/duplicacy-backup-${SUFFIX}" \
+            ./cmd/duplicacy-backup/
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: duplicacy-backup-${{ matrix.suffix }}
+          path: build/duplicacy-backup-${{ matrix.suffix }}
+          if-no-files-found: error
+
+  # ── Release job — runs only on version tags ──────────────────────────
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Collect binaries
+        run: |
+          mkdir -p release
+          find artifacts -type f -name 'duplicacy-backup-*' -exec cp {} release/ \;
+          chmod +x release/*
+          ls -lh release/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: release/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@ build/
 *.dll
 *.so
 *.dylib
-duplicacy-backup
-duplicacy-backup-*
+/duplicacy-backup
+/duplicacy-backup-*
 
 # Test binary
 *.test

--- a/cmd/duplicacy-backup/main.go
+++ b/cmd/duplicacy-backup/main.go
@@ -1,0 +1,598 @@
+// duplicacy-backup is a compiled replacement for the duplicacy-backup.sh script.
+// It performs Duplicacy backups on Synology NAS using btrfs snapshots, with support
+// for local and remote backup modes, safe pruning with threshold guards, and
+// directory-based concurrency locking.
+//
+// Command model:
+//
+//	default                           -> backup only
+//	--backup                          -> backup only
+//	--prune                           -> safe, threshold-guarded policy prune only
+//	--prune --force-prune             -> safe policy prune, threshold override allowed
+//	--prune-deep --force-prune        -> maintenance mode: policy prune + exhaustive exclusive prune
+//	--fix-perms                       -> normalise local repository ownership/permissions
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/btrfs"
+	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/config"
+	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/duplicacy"
+	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/lock"
+	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/logger"
+	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/permissions"
+	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/secrets"
+)
+
+const (
+	rootVolume = "/volume1"
+	logDir     = "/var/log"
+	lockParent = "/var/lock"
+	scriptName = "duplicacy-backup"
+)
+
+// flags holds all CLI flags parsed from arguments.
+type flags struct {
+	mode       string // "backup", "prune", "prune-deep"
+	fixPerms   bool
+	forcePrune bool
+	remoteMode bool
+	dryRun     bool
+	source     string // positional arg: source directory name
+}
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	// Check for --help before any privilege/dependency checks so that
+	// help text is always accessible regardless of environment.
+	for _, arg := range os.Args[1:] {
+		if arg == "--help" {
+			printUsage()
+			return 0
+		}
+	}
+
+	// Must be root
+	if os.Geteuid() != 0 {
+		fmt.Fprintln(os.Stderr, "[ERROR] Must be run as root.")
+		return 1
+	}
+
+	// Check required commands
+	for _, cmd := range []string{"btrfs", "duplicacy"} {
+		if _, err := exec.LookPath(cmd); err != nil {
+			fmt.Fprintf(os.Stderr, "[ERROR] Required command '%s' not found\n", cmd)
+			return 1
+		}
+	}
+
+	// Detect colour support
+	enableColour := isTerminal(os.Stderr)
+
+	// Parse CLI flags
+	f, err := parseFlags(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[ERROR] %v\n", err)
+		return 1
+	}
+
+	// Derive modes
+	doBackup := f.mode == "backup"
+	doPrune := f.mode == "prune" || f.mode == "prune-deep"
+	deepPruneMode := f.mode == "prune-deep"
+
+	// Validate flag combinations
+	if deepPruneMode && !f.forcePrune {
+		fmt.Fprintln(os.Stderr, "[ERROR] --prune-deep requires --force-prune")
+		return 1
+	}
+
+	if f.forcePrune && !doPrune {
+		fmt.Fprintln(os.Stderr, "[WARNING] --force-prune has no effect unless used with --prune or --prune-deep")
+	}
+
+	if f.fixPerms && f.remoteMode {
+		fmt.Fprintln(os.Stderr, "[WARNING] --fix-perms has no effect with --remote")
+	}
+
+	// Timestamps
+	runTimestamp := time.Now().Format("20060102-150405")
+
+	// Set up logger
+	log, err := logger.New(logDir, scriptName, enableColour)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[ERROR] Failed to initialise logger: %v\n", err)
+		return 1
+	}
+	defer log.Close()
+
+	// Derive paths
+	backupLabel := f.source
+	snapshotSource := filepath.Join(rootVolume, backupLabel)
+	snapshotTarget := filepath.Join(rootVolume, fmt.Sprintf("%s-%s", backupLabel, runTimestamp))
+	workRoot := filepath.Join(os.TempDir(), fmt.Sprintf("%s-%s-%s-%d", scriptName, backupLabel, runTimestamp, os.Getpid()))
+
+	var repositoryPath string
+	if doBackup {
+		repositoryPath = snapshotTarget
+	} else {
+		repositoryPath = snapshotSource
+	}
+
+	// Acquire lock
+	lk := lock.New(lockParent, backupLabel)
+
+	// Set up cleanup and signal handling
+	exitCode := 0
+	cleanedUp := false
+
+	doCleanup := func(code int) {
+		if cleanedUp {
+			return
+		}
+		cleanedUp = true
+
+		log.Info("Starting cleanup...")
+
+		if doBackup {
+			if _, err := os.Stat(snapshotTarget); err == nil {
+				log.Info("Deleting snapshot subvolume... %s", snapshotTarget)
+				if delErr := btrfs.DeleteSnapshot(log, snapshotTarget, f.dryRun); delErr != nil {
+					log.Warn("Failed to delete subvolume %s: %v", snapshotTarget, delErr)
+					// Also try rm -rf as fallback
+					os.RemoveAll(snapshotTarget)
+				}
+			}
+		}
+
+		if _, err := os.Stat(workRoot); err == nil {
+			log.Info("Removing duplicacy work directory... %s", workRoot)
+			if f.dryRun {
+				log.DryRun("rm -rf %s", workRoot)
+			} else {
+				os.RemoveAll(workRoot)
+			}
+		}
+
+		lk.Release()
+
+		status := "SUCCESS"
+		if code != 0 {
+			status = "FAILED"
+		}
+
+		log.PrintSeparator()
+		log.Info("Backup script completed:")
+		log.PrintLine("Result", log.FormatResult(status))
+		log.PrintLine("Code", fmt.Sprintf("%d", code))
+		log.PrintLine("Timestamp", time.Now().Format("2006-01-02 15:04:05"))
+		log.PrintSeparator()
+	}
+
+	defer doCleanup(exitCode)
+
+	// Handle signals
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGHUP, syscall.SIGTERM)
+	go func() {
+		sig := <-sigChan
+		log.Warn("Received signal: %v - initiating cleanup...", sig)
+		doCleanup(1)
+		os.Exit(1)
+	}()
+
+	// Acquire the lock
+	if err := lk.Acquire(); err != nil {
+		log.Error("Lock acquisition failed: %v", err)
+		exitCode = 1
+		return exitCode
+	}
+
+	// Header
+	log.PrintSeparator()
+	log.Info("Backup Script Started - %s", time.Now().Format("2006-01-02 15:04:05"))
+	log.PrintLine("Script", scriptName)
+	log.PrintLine("PID", fmt.Sprintf("%d", os.Getpid()))
+	log.PrintLine("Lock Path", lk.Path)
+	log.PrintSeparator()
+
+	// Load config
+	execPath, err := os.Executable()
+	if err != nil {
+		log.Error("Failed to determine executable path: %v", err)
+		exitCode = 1
+		return exitCode
+	}
+	scriptDir := filepath.Dir(execPath)
+	configDir := filepath.Join(scriptDir, ".config")
+	configFile := filepath.Join(configDir, fmt.Sprintf("%s-backup.conf", backupLabel))
+
+	if _, err := os.Stat(configFile); os.IsNotExist(err) {
+		log.Error("Configuration file %s not found", configFile)
+		exitCode = 1
+		return exitCode
+	}
+
+	// Parse config
+	cfg := config.NewDefaults()
+
+	targetSection := "local"
+	if f.remoteMode {
+		targetSection = "remote"
+	}
+
+	values, err := config.ParseFile(configFile, targetSection)
+	if err != nil {
+		log.Error("Config parse error: %v", err)
+		exitCode = 1
+		return exitCode
+	}
+	cfg.Apply(values)
+
+	log.Info("Config file %s parsed for [common] + [%s]", configFile, targetSection)
+
+	// Clean up old logs
+	log.CleanupOldLogs(cfg.LogRetentionDays, f.dryRun)
+
+	// Validate config
+	if err := cfg.ValidateRequired(doBackup, doPrune); err != nil {
+		log.Error("Config file: %s", configFile)
+		log.Error("%v", err)
+		exitCode = 1
+		return exitCode
+	}
+
+	if err := cfg.ValidateThresholds(); err != nil {
+		log.Error("%v", err)
+		exitCode = 1
+		return exitCode
+	}
+
+	if err := cfg.ValidateOwnerGroup(); err != nil {
+		log.Error("%v", err)
+		exitCode = 1
+		return exitCode
+	}
+
+	cfg.BuildPruneArgs()
+
+	if doBackup {
+		if err := cfg.ValidateThreads(); err != nil {
+			log.Error("%v", err)
+			exitCode = 1
+			return exitCode
+		}
+	}
+
+	// Check btrfs volumes
+	if err := btrfs.CheckVolume(log, rootVolume, f.dryRun); err != nil {
+		log.Error("%v", err)
+		exitCode = 1
+		return exitCode
+	}
+
+	if doBackup {
+		if err := btrfs.CheckVolume(log, snapshotSource, f.dryRun); err != nil {
+			log.Error("%v", err)
+			exitCode = 1
+			return exitCode
+		}
+	}
+
+	// Load secrets for remote mode
+	backupTarget := filepath.Join(cfg.Destination, backupLabel)
+	var sec *secrets.Secrets
+
+	if f.remoteMode {
+		secretsFile := secrets.GetSecretsFilePath(config.DefaultSecretsDir, config.DefaultSecretsPrefix, backupLabel)
+		sec, err = secrets.LoadSecretsFile(secretsFile)
+		if err != nil {
+			log.Error("%v", err)
+			exitCode = 1
+			return exitCode
+		}
+		if err := sec.Validate(); err != nil {
+			log.Error("%v", err)
+			exitCode = 1
+			return exitCode
+		}
+		log.Info("Secrets loaded from %s", secretsFile)
+	}
+
+	// Print config summary
+	modeStr := "LOCAL"
+	if f.remoteMode {
+		modeStr = "REMOTE"
+	}
+
+	log.Info("Configuration Summary:")
+	log.PrintLine("Config File", configFile)
+	log.PrintLine("Backup Label", backupLabel)
+	log.PrintLine("Mode", modeStr)
+	log.PrintLine("Source", snapshotSource)
+	log.PrintLine("Repository", repositoryPath)
+	log.PrintLine("Work Dir", filepath.Join(workRoot, "duplicacy"))
+	log.PrintLine("Destination", backupTarget)
+	if cfg.Threads > 0 {
+		log.PrintLine("Threads", fmt.Sprintf("%d", cfg.Threads))
+	} else {
+		log.PrintLine("Threads", "<n/a>")
+	}
+	if cfg.Filter != "" {
+		log.PrintLine("Filter", cfg.Filter)
+	} else {
+		log.PrintLine("Filter", "<none>")
+	}
+	if cfg.Prune != "" {
+		log.PrintLine("Prune Options", cfg.Prune)
+	} else {
+		log.PrintLine("Prune Options", "<none>")
+	}
+	log.PrintLine("Local Owner", cfg.LocalOwner)
+	log.PrintLine("Local Group", cfg.LocalGroup)
+	log.PrintLine("Log Retention", fmt.Sprintf("%d", cfg.LogRetentionDays))
+	log.PrintLine("Dry Run", fmt.Sprintf("%t", f.dryRun))
+	log.PrintLine("Force Prune", fmt.Sprintf("%t", f.forcePrune))
+	log.PrintLine("Fix Perms", fmt.Sprintf("%t", f.fixPerms))
+	log.PrintLine("Prune Max %", fmt.Sprintf("%d", cfg.SafePruneMaxDeletePercent))
+	log.PrintLine("Prune Max Count", fmt.Sprintf("%d", cfg.SafePruneMaxDeleteCount))
+	log.PrintLine("Prune Min Total %", fmt.Sprintf("%d", cfg.SafePruneMinTotalForPercent))
+
+	if f.remoteMode && sec != nil {
+		log.PrintLine("Secrets File", secrets.GetSecretsFilePath(config.DefaultSecretsDir, config.DefaultSecretsPrefix, backupLabel))
+		log.PrintLine("STORJ S3 ID", sec.MaskedID())
+		log.PrintLine("STORJ S3 Secret", sec.MaskedSecret())
+	}
+
+	// Print operation mode
+	if doBackup {
+		log.PrintLine("Operation Mode", "Backup only")
+	} else if doPrune && deepPruneMode {
+		log.PrintLine("Operation Mode", "Prune deep")
+	} else if doPrune {
+		log.PrintLine("Operation Mode", "Prune safe")
+	}
+
+	// Create btrfs snapshot for backup
+	if doBackup {
+		if err := btrfs.CreateSnapshot(log, snapshotSource, snapshotTarget, f.dryRun); err != nil {
+			log.Error("Failed to create snapshot: %v", err)
+			exitCode = 1
+			return exitCode
+		}
+	}
+
+	// Set up duplicacy working environment
+	dup := duplicacy.NewSetup(workRoot, repositoryPath, backupTarget, log, f.dryRun)
+
+	if err := dup.CreateDirs(); err != nil {
+		log.Error("%v", err)
+		exitCode = 1
+		return exitCode
+	}
+
+	// Write preferences
+	if err := dup.WritePreferences(sec); err != nil {
+		log.Error("Failed to write preferences: %v", err)
+		exitCode = 1
+		return exitCode
+	}
+
+	// Write filters for backup mode
+	if doBackup && cfg.Filter != "" {
+		if err := dup.WriteFilters(cfg.Filter); err != nil {
+			log.Error("%v", err)
+			exitCode = 1
+			return exitCode
+		}
+	}
+
+	// Set permissions on work directory
+	if err := dup.SetPermissions(); err != nil {
+		log.Error("%v", err)
+		exitCode = 1
+		return exitCode
+	}
+
+	log.Info("Changing to directory: %s", dup.DuplicacyRoot)
+
+	// Run backup
+	if doBackup {
+		if err := dup.RunBackup(cfg.Threads); err != nil {
+			log.Error("Backup failed: %v", err)
+			exitCode = 1
+			return exitCode
+		}
+	}
+
+	// Run prune
+	if doPrune {
+		if err := dup.ValidateRepo(); err != nil {
+			log.Error("Cannot perform prune operation - repository not ready: %v", err)
+			exitCode = 1
+			return exitCode
+		}
+
+		preview, err := dup.SafePrunePreview(cfg.PruneArgs, cfg.SafePruneMinTotalForPercent)
+		if err != nil {
+			log.Error("Safe prune preview failed: %v", err)
+			exitCode = 1
+			return exitCode
+		}
+
+		// Display preview
+		log.PrintLine("Preview Deletes", fmt.Sprintf("%d", preview.DeleteCount))
+		log.PrintLine("Preview Total Revs", fmt.Sprintf("%d", preview.TotalRevisions))
+		if preview.PercentEnforced {
+			log.PrintLine("Preview Delete %", fmt.Sprintf("%d", preview.DeletePercent))
+		} else {
+			log.PrintLine("Preview Delete %", fmt.Sprintf("<not enforced; total revisions unavailable or below %d>", cfg.SafePruneMinTotalForPercent))
+		}
+
+		// Check thresholds
+		blocked := false
+		if preview.DeleteCount > cfg.SafePruneMaxDeleteCount {
+			log.Error("Safe prune preview exceeds delete count threshold: %d > %d", preview.DeleteCount, cfg.SafePruneMaxDeleteCount)
+			blocked = true
+		}
+		if preview.PercentEnforced && preview.DeletePercent > cfg.SafePruneMaxDeletePercent {
+			log.Error("Safe prune preview exceeds delete percentage threshold: %d%% > %d%%", preview.DeletePercent, cfg.SafePruneMaxDeletePercent)
+			blocked = true
+		}
+
+		if blocked {
+			if f.forcePrune {
+				log.Warn("Proceeding despite safe prune threshold breach because --force-prune was supplied")
+			} else {
+				log.Error("Refusing to continue because safe prune thresholds were exceeded")
+				exitCode = 1
+				return exitCode
+			}
+		}
+
+		if err := dup.RunPrune(cfg.PruneArgs); err != nil {
+			log.Error("Policy prune failed: %v", err)
+			exitCode = 1
+			return exitCode
+		}
+
+		if deepPruneMode {
+			if err := dup.RunDeepPrune(); err != nil {
+				log.Error("Deep prune failed: %v", err)
+				exitCode = 1
+				return exitCode
+			}
+		}
+	}
+
+	// Fix permissions for local mode
+	if !f.remoteMode && f.fixPerms {
+		if err := permissions.Fix(log, backupTarget, cfg.LocalOwner, cfg.LocalGroup, f.dryRun); err != nil {
+			log.Error("%v", err)
+			exitCode = 1
+			return exitCode
+		}
+	}
+
+	log.Info("All operations completed")
+	return 0
+}
+
+func parseFlags(args []string) (*flags, error) {
+	f := &flags{mode: ""}
+	var positional []string
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--backup", "--prune", "--prune-deep":
+			if f.mode != "" {
+				return nil, fmt.Errorf("only one mode may be specified: --backup, --prune, or --prune-deep")
+			}
+			f.mode = strings.TrimPrefix(args[i], "--")
+		case "--fix-perms":
+			f.fixPerms = true
+		case "--force-prune":
+			f.forcePrune = true
+		case "--remote":
+			f.remoteMode = true
+		case "--dry-run":
+			f.dryRun = true
+		case "--help":
+			printUsage()
+			os.Exit(0)
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return nil, fmt.Errorf("unknown option %s", args[i])
+			}
+			positional = append(positional, args[i])
+		}
+	}
+
+	// Default mode is backup
+	if f.mode == "" {
+		f.mode = "backup"
+	}
+
+	if len(positional) < 1 {
+		return nil, fmt.Errorf("source directory required")
+	}
+
+	f.source = positional[0]
+	return f, nil
+}
+
+func printUsage() {
+	fmt.Printf(`Usage: %s [OPTIONS] <source>
+
+DEFAULT BEHAVIOUR:
+    No mode specified = backup only
+
+MODES:
+    --backup                 Perform backup only
+    --prune                  Perform safe, threshold-guarded policy prune only
+    --prune-deep             Perform maintenance prune mode (requires --force-prune):
+                             policy prune + exhaustive exclusive prune
+
+MODIFIERS:
+    --fix-perms              Normalise local repository ownership and permissions
+    --force-prune            Override safe prune thresholds, or authorise --prune-deep
+    --remote                 Perform operation against remote target config
+    --dry-run                Simulate actions without making changes
+    --help                   Show this help message
+
+SAFE PRUNE THRESHOLDS:
+    Max delete percent       : %d%% (default %d%%)
+    Max delete count         : %d (default %d)
+    Min revisions for %% check: %d (default %d)
+
+CONFIG FILE LOCATION:
+    <executable-dir>/.config/<source>-backup.conf
+
+CONFIG KEYS:
+    DESTINATION, FILTER, LOCAL_OWNER, LOCAL_GROUP, LOG_RETENTION_DAYS,
+    PRUNE, THREADS, SAFE_PRUNE_MAX_DELETE_COUNT, SAFE_PRUNE_MAX_DELETE_PERCENT,
+    SAFE_PRUNE_MIN_TOTAL_FOR_PERCENT
+
+REMOTE SECRETS:
+    Strict mode: remote credentials are loaded only from:
+      %s/%s-<label>.env
+
+ARGUMENTS:
+    source                   Source directory name under %s
+
+EXAMPLES:
+    %s homes
+    %s --backup homes
+    %s --prune homes
+    %s --prune --force-prune homes
+    %s --prune-deep --force-prune homes
+    %s --fix-perms homes
+    %s --remote homes
+`, scriptName,
+		config.DefaultSafePruneMaxDeletePercent, config.DefaultSafePruneMaxDeletePercent,
+		config.DefaultSafePruneMaxDeleteCount, config.DefaultSafePruneMaxDeleteCount,
+		config.DefaultSafePruneMinTotalForPercent, config.DefaultSafePruneMinTotalForPercent,
+		config.DefaultSecretsDir, config.DefaultSecretsPrefix,
+		rootVolume,
+		scriptName, scriptName, scriptName, scriptName, scriptName, scriptName, scriptName,
+	)
+}
+
+func isTerminal(f *os.File) bool {
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}


### PR DESCRIPTION
The .gitignore pattern 'duplicacy-backup' was matching the source directory cmd/duplicacy-backup/, preventing it from being committed. Changed to '/duplicacy-backup' so it only ignores the root-level binary, not the source directory.

Also adds the GitHub Actions CI workflow (build.yml) and the main.go entry point that were previously untracked.