### PR TITLE
release: prepare v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-04-08
+
+First public release.
+
+### Added
+- MIT LICENSE file.
+- `--version` flag to display version and build time.
+- CHANGELOG.md for tracking releases.
+- Mandatory validation for `LOCAL_OWNER` and `LOCAL_GROUP` configuration fields.
+- New tests for mandatory owner/group validation (`TestValidateOwnerGroup_MissingOwnerReturnsError`,
+  `TestValidateOwnerGroup_MissingGroupReturnsError`).
+
+### Changed
+- **BREAKING:** `LOCAL_OWNER` and `LOCAL_GROUP` are now **mandatory** configuration fields.
+  They no longer have default values.  Every `.conf` file must explicitly set both fields
+  to a non-root user/group for security.  The script will refuse to start if they are missing.
+- Updated example configuration with clear comments explaining the mandatory fields.
+- Updated README documentation to reflect the new requirements.
+
+### Fixed
+- Cleanup logic bug: `defer doCleanup(exitCode)` captured the exit code by value
+  (always 0); replaced with `defer func() { doCleanup(exitCode) }()` so the
+  actual exit status is reported.
+- Version flag: declared `version` and `buildTime` variables in `main.go` so
+  that `go build -ldflags "-X main.version=... -X main.buildTime=..."` works
+  correctly.
+
+### Removed
+- `DefaultLocalOwner` and `DefaultLocalGroup` constants (replaced by mandatory validation).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Phillip McMahon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ This means the config directory travels with the binary — useful for portable 
 | `THREADS` | Yes (backup) | Number of threads (power of 2, max 16) |
 | `PRUNE` | Yes (prune) | Duplicacy prune retention arguments |
 | `FILTER` | No | Duplicacy filter pattern using regex syntax (`e:` prefix to exclude, `i:` to include) |
-| `LOCAL_OWNER` | No | Local repo owner (default: `phillipmcmahon`) |
-| `LOCAL_GROUP` | No | Local repo group (default: `users`) |
+| `LOCAL_OWNER` | **Yes** | Owner of local backup files (e.g. `myuser`). **Must not be root** — the script runs as root but files should be owned by a regular user for security. |
+| `LOCAL_GROUP` | **Yes** | Group for local backup files (e.g. `users`). |
 | `LOG_RETENTION_DAYS` | No | Days to keep log files (default: `30`) |
 | `SAFE_PRUNE_MAX_DELETE_PERCENT` | No | Max deletion percentage (default: `10`) |
 | `SAFE_PRUNE_MAX_DELETE_COUNT` | No | Max deletion count (default: `25`) |
@@ -269,6 +269,8 @@ synology-duplicacy-backup/
 ├── examples/
 │   ├── homes-backup.conf        # Example configuration file
 │   └── duplicacy-homes.env.example  # Example secrets file
+├── CHANGELOG.md                 # Release history
+├── LICENSE                      # MIT license
 ├── Makefile                     # Build targets including Synology cross-compilation
 ├── go.mod                       # Go module definition
 ├── .gitignore

--- a/cmd/duplicacy-backup/main.go
+++ b/cmd/duplicacy-backup/main.go
@@ -33,6 +33,15 @@ import (
         "github.com/phillipmcmahon/synology-duplicacy-backup/internal/secrets"
 )
 
+// version and buildTime are set at build time via -ldflags.
+// See Makefile for the injection pattern:
+//
+//      go build -ldflags "-X main.version=... -X main.buildTime=..."
+var (
+        version   = "dev"
+        buildTime = "unknown"
+)
+
 const (
         rootVolume = "/volume1"
         logDir     = "/var/log"
@@ -82,11 +91,15 @@ func main() {
 }
 
 func run() int {
-        // Check for --help before any privilege/dependency checks so that
-        // help text is always accessible regardless of environment.
+        // Check for --help and --version before any privilege/dependency checks
+        // so that help/version text is always accessible regardless of environment.
         for _, arg := range os.Args[1:] {
                 if arg == "--help" {
                         printUsage()
+                        return 0
+                }
+                if arg == "--version" {
+                        fmt.Printf("%s %s (built %s)\n", scriptName, version, buildTime)
                         return 0
                 }
         }
@@ -214,7 +227,9 @@ func run() int {
                 log.PrintSeparator()
         }
 
-        defer doCleanup(exitCode)
+        // Use a closure so that doCleanup receives the final value of exitCode,
+        // not the value at the time defer is evaluated (which would always be 0).
+        defer func() { doCleanup(exitCode) }()
 
         // Handle signals
         sigChan := make(chan os.Signal, 1)
@@ -568,6 +583,9 @@ func parseFlags(args []string) (*flags, error) {
                 case "--help":
                         printUsage()
                         os.Exit(0)
+                case "--version":
+                        fmt.Printf("%s %s (built %s)\n", scriptName, version, buildTime)
+                        os.Exit(0)
                 default:
                         if strings.HasPrefix(args[i], "-") {
                                 return nil, fmt.Errorf("unknown option %s", args[i])
@@ -609,6 +627,7 @@ MODIFIERS:
     --dry-run                Simulate actions without making changes
     --config-dir <path>      Override config directory (default: <binary-dir>/.config)
     --secrets-dir <path>     Override secrets directory (default: %s)
+    --version                Show version and build information
     --help                   Show this help message
 
 ENVIRONMENT VARIABLES:

--- a/examples/homes-backup.conf
+++ b/examples/homes-backup.conf
@@ -20,7 +20,10 @@ PRUNE=-keep 1:728 -keep 91:364 -keep 28:182 -keep 7:28
 # See: https://github.com/gilbertchen/duplicacy/wiki/Include-Exclude-Patterns
 FILTER=e:^(.*/)?(@eaDir|#recycle|tmp|exclude)/$|^(.*/)?(\.DS_Store|\._.*|Thumbs\.db)$
 
-# Local repository ownership
+# REQUIRED: Local repository ownership.
+# The script runs as root, but backup files should be owned by a regular
+# (non-root) user for security.  These fields have no default — you MUST
+# set them or the script will refuse to start.
 LOCAL_OWNER=myuser
 LOCAL_GROUP=users
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,8 +16,6 @@ const (
         DefaultSafePruneMaxDeletePercent   = 10
         DefaultSafePruneMaxDeleteCount     = 25
         DefaultSafePruneMinTotalForPercent = 20
-        DefaultLocalOwner                  = "phillipmcmahon"
-        DefaultLocalGroup                  = "users"
         DefaultLogRetentionDays            = 30
         DefaultSecretsDir = "/root/.secrets"
         DefaultSecretsPrefix               = "duplicacy"
@@ -57,10 +55,10 @@ type Config struct {
 }
 
 // NewDefaults returns a Config with all default values.
+// Note: LocalOwner and LocalGroup are mandatory and have no defaults —
+// they must be explicitly set in the configuration file.
 func NewDefaults() *Config {
         return &Config{
-                LocalOwner:                  DefaultLocalOwner,
-                LocalGroup:                  DefaultLocalGroup,
                 LogRetentionDays:            DefaultLogRetentionDays,
                 SafePruneMaxDeletePercent:   DefaultSafePruneMaxDeletePercent,
                 SafePruneMaxDeleteCount:     DefaultSafePruneMaxDeleteCount,
@@ -247,8 +245,17 @@ func (c *Config) ValidateThresholds() error {
         return nil
 }
 
-// ValidateOwnerGroup validates local owner and group names.
+// ValidateOwnerGroup validates that local owner and group are specified and
+// contain valid Unix username characters.  These fields are mandatory — the
+// backup runs as root but repository files must be owned by a non-root user
+// for security.
 func (c *Config) ValidateOwnerGroup() error {
+        if c.LocalOwner == "" {
+                return fmt.Errorf("LOCAL_OWNER is mandatory: set it in your .conf file to the non-root user that should own backup files (e.g. LOCAL_OWNER=myuser)")
+        }
+        if c.LocalGroup == "" {
+                return fmt.Errorf("LOCAL_GROUP is mandatory: set it in your .conf file to the group that should own backup files (e.g. LOCAL_GROUP=users)")
+        }
         if !ownerPattern.MatchString(c.LocalOwner) {
                 return fmt.Errorf("LOCAL_OWNER has invalid value '%s'", c.LocalOwner)
         }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,27 +1,27 @@
 package config
 
 import (
-	"os"
-	"path/filepath"
-	"strings"
-	"testing"
+        "os"
+        "path/filepath"
+        "strings"
+        "testing"
 )
 
 // helper to write a temp config file and return its path.
 func writeTempConfig(t *testing.T, content string) string {
-	t.Helper()
-	dir := t.TempDir()
-	p := filepath.Join(dir, "test.conf")
-	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
-		t.Fatalf("failed to write temp config: %v", err)
-	}
-	return p
+        t.Helper()
+        dir := t.TempDir()
+        p := filepath.Join(dir, "test.conf")
+        if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+                t.Fatalf("failed to write temp config: %v", err)
+        }
+        return p
 }
 
 // ─── ParseFile tests ─────────────────────────────────────────────────────────
 
 func TestParseFile_ValidConfig(t *testing.T) {
-	p := writeTempConfig(t, `[common]
+        p := writeTempConfig(t, `[common]
 DESTINATION=/volume1/backups
 FILTER="-e \.DS_Store"
 [local]
@@ -29,60 +29,60 @@ THREADS=4
 LOCAL_OWNER=admin
 LOCAL_GROUP=users
 `)
-	vals, err := ParseFile(p, "local")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	expect := map[string]string{
-		"DESTINATION": "/volume1/backups",
-		"FILTER":      `-e \.DS_Store`,
-		"THREADS":     "4",
-		"LOCAL_OWNER": "admin",
-		"LOCAL_GROUP": "users",
-	}
-	for k, want := range expect {
-		if got := vals[k]; got != want {
-			t.Errorf("vals[%q] = %q, want %q", k, got, want)
-		}
-	}
+        vals, err := ParseFile(p, "local")
+        if err != nil {
+                t.Fatalf("unexpected error: %v", err)
+        }
+        expect := map[string]string{
+                "DESTINATION": "/volume1/backups",
+                "FILTER":      `-e \.DS_Store`,
+                "THREADS":     "4",
+                "LOCAL_OWNER": "admin",
+                "LOCAL_GROUP": "users",
+        }
+        for k, want := range expect {
+                if got := vals[k]; got != want {
+                        t.Errorf("vals[%q] = %q, want %q", k, got, want)
+                }
+        }
 }
 
 func TestParseFile_TargetSectionOverridesCommon(t *testing.T) {
-	p := writeTempConfig(t, `[common]
+        p := writeTempConfig(t, `[common]
 DESTINATION=/volume1/backups
 THREADS=2
 [local]
 THREADS=8
 `)
-	vals, err := ParseFile(p, "local")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if vals["THREADS"] != "8" {
-		t.Errorf("expected THREADS=8 (local override), got %q", vals["THREADS"])
-	}
+        vals, err := ParseFile(p, "local")
+        if err != nil {
+                t.Fatalf("unexpected error: %v", err)
+        }
+        if vals["THREADS"] != "8" {
+                t.Errorf("expected THREADS=8 (local override), got %q", vals["THREADS"])
+        }
 }
 
 func TestParseFile_IgnoresUnrelatedSections(t *testing.T) {
-	p := writeTempConfig(t, `[common]
+        p := writeTempConfig(t, `[common]
 DESTINATION=/volume1/backups
 [remote]
 THREADS=2
 [local]
 THREADS=8
 `)
-	vals, err := ParseFile(p, "local")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	// THREADS should be 8 from [local], not 2 from [remote]
-	if vals["THREADS"] != "8" {
-		t.Errorf("expected THREADS=8, got %q", vals["THREADS"])
-	}
+        vals, err := ParseFile(p, "local")
+        if err != nil {
+                t.Fatalf("unexpected error: %v", err)
+        }
+        // THREADS should be 8 from [local], not 2 from [remote]
+        if vals["THREADS"] != "8" {
+                t.Errorf("expected THREADS=8, got %q", vals["THREADS"])
+        }
 }
 
 func TestParseFile_CommentsAndBlankLinesIgnored(t *testing.T) {
-	p := writeTempConfig(t, `
+        p := writeTempConfig(t, `
 # This is a comment
 [common]
 # Another comment
@@ -91,541 +91,574 @@ DESTINATION=/volume1/backups
 [local]
 THREADS=4
 `)
-	vals, err := ParseFile(p, "local")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if vals["DESTINATION"] != "/volume1/backups" {
-		t.Errorf("DESTINATION = %q", vals["DESTINATION"])
-	}
+        vals, err := ParseFile(p, "local")
+        if err != nil {
+                t.Fatalf("unexpected error: %v", err)
+        }
+        if vals["DESTINATION"] != "/volume1/backups" {
+                t.Errorf("DESTINATION = %q", vals["DESTINATION"])
+        }
 }
 
 func TestParseFile_QuoteStripping(t *testing.T) {
-	p := writeTempConfig(t, `[common]
+        p := writeTempConfig(t, `[common]
 DESTINATION="/volume1/backups"
 [local]
 THREADS=4
 `)
-	vals, err := ParseFile(p, "local")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if vals["DESTINATION"] != "/volume1/backups" {
-		t.Errorf("expected quotes stripped, got %q", vals["DESTINATION"])
-	}
+        vals, err := ParseFile(p, "local")
+        if err != nil {
+                t.Fatalf("unexpected error: %v", err)
+        }
+        if vals["DESTINATION"] != "/volume1/backups" {
+                t.Errorf("expected quotes stripped, got %q", vals["DESTINATION"])
+        }
 }
 
 func TestParseFile_MissingCommonSection(t *testing.T) {
-	p := writeTempConfig(t, `[local]
+        p := writeTempConfig(t, `[local]
 DESTINATION=/volume1/backups
 `)
-	_, err := ParseFile(p, "local")
-	if err == nil {
-		t.Fatal("expected error for missing [common] section, got nil")
-	}
-	if !strings.Contains(err.Error(), "[common]") {
-		t.Errorf("error should mention [common], got: %v", err)
-	}
+        _, err := ParseFile(p, "local")
+        if err == nil {
+                t.Fatal("expected error for missing [common] section, got nil")
+        }
+        if !strings.Contains(err.Error(), "[common]") {
+                t.Errorf("error should mention [common], got: %v", err)
+        }
 }
 
 func TestParseFile_MissingTargetSection_Local(t *testing.T) {
-	p := writeTempConfig(t, `[common]
+        p := writeTempConfig(t, `[common]
 DESTINATION=/volume1/backups
 `)
-	_, err := ParseFile(p, "local")
-	if err == nil {
-		t.Fatal("expected error for missing [local] section, got nil")
-	}
-	if !strings.Contains(err.Error(), "[local]") {
-		t.Errorf("error should mention [local], got: %v", err)
-	}
+        _, err := ParseFile(p, "local")
+        if err == nil {
+                t.Fatal("expected error for missing [local] section, got nil")
+        }
+        if !strings.Contains(err.Error(), "[local]") {
+                t.Errorf("error should mention [local], got: %v", err)
+        }
 }
 
 func TestParseFile_MissingTargetSection_Remote(t *testing.T) {
-	p := writeTempConfig(t, `[common]
+        p := writeTempConfig(t, `[common]
 DESTINATION=s3://bucket
 [local]
 THREADS=4
 `)
-	_, err := ParseFile(p, "remote")
-	if err == nil {
-		t.Fatal("expected error for missing [remote] section, got nil")
-	}
-	if !strings.Contains(err.Error(), "[remote]") {
-		t.Errorf("error should mention [remote], got: %v", err)
-	}
+        _, err := ParseFile(p, "remote")
+        if err == nil {
+                t.Fatal("expected error for missing [remote] section, got nil")
+        }
+        if !strings.Contains(err.Error(), "[remote]") {
+                t.Errorf("error should mention [remote], got: %v", err)
+        }
 }
 
 func TestParseFile_DuplicateSection(t *testing.T) {
-	p := writeTempConfig(t, `[common]
+        p := writeTempConfig(t, `[common]
 DESTINATION=/volume1/backups
 [local]
 THREADS=4
 [local]
 THREADS=8
 `)
-	_, err := ParseFile(p, "local")
-	if err == nil {
-		t.Fatal("expected error for duplicate section")
-	}
-	if !strings.Contains(err.Error(), "duplicate") {
-		t.Errorf("error should mention duplicate, got: %v", err)
-	}
+        _, err := ParseFile(p, "local")
+        if err == nil {
+                t.Fatal("expected error for duplicate section")
+        }
+        if !strings.Contains(err.Error(), "duplicate") {
+                t.Errorf("error should mention duplicate, got: %v", err)
+        }
 }
 
 func TestParseFile_ContentOutsideSection(t *testing.T) {
-	p := writeTempConfig(t, `DESTINATION=/volume1/backups
+        p := writeTempConfig(t, `DESTINATION=/volume1/backups
 [common]
 THREADS=4
 [local]
 THREADS=2
 `)
-	_, err := ParseFile(p, "local")
-	if err == nil {
-		t.Fatal("expected error for content outside section")
-	}
-	if !strings.Contains(err.Error(), "outside") {
-		t.Errorf("error should mention 'outside', got: %v", err)
-	}
+        _, err := ParseFile(p, "local")
+        if err == nil {
+                t.Fatal("expected error for content outside section")
+        }
+        if !strings.Contains(err.Error(), "outside") {
+                t.Errorf("error should mention 'outside', got: %v", err)
+        }
 }
 
 func TestParseFile_InvalidLineNoEquals(t *testing.T) {
-	p := writeTempConfig(t, `[common]
+        p := writeTempConfig(t, `[common]
 DESTINATION /volume1/backups
 [local]
 THREADS=4
 `)
-	_, err := ParseFile(p, "local")
-	if err == nil {
-		t.Fatal("expected error for invalid line")
-	}
-	if !strings.Contains(err.Error(), "key=value") {
-		t.Errorf("error should mention key=value, got: %v", err)
-	}
+        _, err := ParseFile(p, "local")
+        if err == nil {
+                t.Fatal("expected error for invalid line")
+        }
+        if !strings.Contains(err.Error(), "key=value") {
+                t.Errorf("error should mention key=value, got: %v", err)
+        }
 }
 
 func TestParseFile_EmptyKey(t *testing.T) {
-	p := writeTempConfig(t, `[common]
+        p := writeTempConfig(t, `[common]
 =/volume1/backups
 [local]
 THREADS=4
 `)
-	_, err := ParseFile(p, "local")
-	if err == nil {
-		t.Fatal("expected error for empty key")
-	}
-	if !strings.Contains(err.Error(), "missing key") {
-		t.Errorf("error should mention 'missing key', got: %v", err)
-	}
+        _, err := ParseFile(p, "local")
+        if err == nil {
+                t.Fatal("expected error for empty key")
+        }
+        if !strings.Contains(err.Error(), "missing key") {
+                t.Errorf("error should mention 'missing key', got: %v", err)
+        }
 }
 
 func TestParseFile_UnknownKey(t *testing.T) {
-	p := writeTempConfig(t, `[common]
+        p := writeTempConfig(t, `[common]
 DESTINATION=/volume1/backups
 UNKNOWN_KEY=foo
 [local]
 THREADS=4
 `)
-	_, err := ParseFile(p, "local")
-	if err == nil {
-		t.Fatal("expected error for unknown key")
-	}
-	if !strings.Contains(err.Error(), "not permitted") {
-		t.Errorf("error should mention 'not permitted', got: %v", err)
-	}
+        _, err := ParseFile(p, "local")
+        if err == nil {
+                t.Fatal("expected error for unknown key")
+        }
+        if !strings.Contains(err.Error(), "not permitted") {
+                t.Errorf("error should mention 'not permitted', got: %v", err)
+        }
 }
 
 func TestParseFile_InvalidKeyPattern(t *testing.T) {
-	p := writeTempConfig(t, `[common]
+        p := writeTempConfig(t, `[common]
 lower_case=value
 [local]
 THREADS=4
 `)
-	_, err := ParseFile(p, "local")
-	if err == nil {
-		t.Fatal("expected error for invalid key pattern")
-	}
-	if !strings.Contains(err.Error(), "invalid config key") {
-		t.Errorf("error should mention 'invalid config key', got: %v", err)
-	}
+        _, err := ParseFile(p, "local")
+        if err == nil {
+                t.Fatal("expected error for invalid key pattern")
+        }
+        if !strings.Contains(err.Error(), "invalid config key") {
+                t.Errorf("error should mention 'invalid config key', got: %v", err)
+        }
 }
 
 func TestParseFile_NonexistentFile(t *testing.T) {
-	_, err := ParseFile("/nonexistent/config.conf", "local")
-	if err == nil {
-		t.Fatal("expected error for nonexistent file")
-	}
+        _, err := ParseFile("/nonexistent/config.conf", "local")
+        if err == nil {
+                t.Fatal("expected error for nonexistent file")
+        }
 }
 
 // ─── Apply tests ─────────────────────────────────────────────────────────────
 
 func TestApply_ValidNumericValues(t *testing.T) {
-	cfg := NewDefaults()
-	vals := map[string]string{
-		"THREADS":                          "8",
-		"LOG_RETENTION_DAYS":               "14",
-		"SAFE_PRUNE_MAX_DELETE_COUNT":      "50",
-		"SAFE_PRUNE_MAX_DELETE_PERCENT":    "20",
-		"SAFE_PRUNE_MIN_TOTAL_FOR_PERCENT": "10",
-	}
-	if err := cfg.Apply(vals); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cfg.Threads != 8 {
-		t.Errorf("Threads = %d, want 8", cfg.Threads)
-	}
-	if cfg.LogRetentionDays != 14 {
-		t.Errorf("LogRetentionDays = %d, want 14", cfg.LogRetentionDays)
-	}
-	if cfg.SafePruneMaxDeleteCount != 50 {
-		t.Errorf("SafePruneMaxDeleteCount = %d, want 50", cfg.SafePruneMaxDeleteCount)
-	}
-	if cfg.SafePruneMaxDeletePercent != 20 {
-		t.Errorf("SafePruneMaxDeletePercent = %d, want 20", cfg.SafePruneMaxDeletePercent)
-	}
-	if cfg.SafePruneMinTotalForPercent != 10 {
-		t.Errorf("SafePruneMinTotalForPercent = %d, want 10", cfg.SafePruneMinTotalForPercent)
-	}
+        cfg := NewDefaults()
+        vals := map[string]string{
+                "THREADS":                          "8",
+                "LOG_RETENTION_DAYS":               "14",
+                "SAFE_PRUNE_MAX_DELETE_COUNT":      "50",
+                "SAFE_PRUNE_MAX_DELETE_PERCENT":    "20",
+                "SAFE_PRUNE_MIN_TOTAL_FOR_PERCENT": "10",
+        }
+        if err := cfg.Apply(vals); err != nil {
+                t.Fatalf("unexpected error: %v", err)
+        }
+        if cfg.Threads != 8 {
+                t.Errorf("Threads = %d, want 8", cfg.Threads)
+        }
+        if cfg.LogRetentionDays != 14 {
+                t.Errorf("LogRetentionDays = %d, want 14", cfg.LogRetentionDays)
+        }
+        if cfg.SafePruneMaxDeleteCount != 50 {
+                t.Errorf("SafePruneMaxDeleteCount = %d, want 50", cfg.SafePruneMaxDeleteCount)
+        }
+        if cfg.SafePruneMaxDeletePercent != 20 {
+                t.Errorf("SafePruneMaxDeletePercent = %d, want 20", cfg.SafePruneMaxDeletePercent)
+        }
+        if cfg.SafePruneMinTotalForPercent != 10 {
+                t.Errorf("SafePruneMinTotalForPercent = %d, want 10", cfg.SafePruneMinTotalForPercent)
+        }
 }
 
 func TestApply_StringValues(t *testing.T) {
-	cfg := NewDefaults()
-	vals := map[string]string{
-		"DESTINATION": "/volume1/backups",
-		"FILTER":      "-e *.tmp",
-		"LOCAL_OWNER": "admin",
-		"LOCAL_GROUP": "staff",
-		"PRUNE":       "-keep 0:365 -keep 30:180",
-	}
-	if err := cfg.Apply(vals); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cfg.Destination != "/volume1/backups" {
-		t.Errorf("Destination = %q", cfg.Destination)
-	}
-	if cfg.Filter != "-e *.tmp" {
-		t.Errorf("Filter = %q", cfg.Filter)
-	}
-	if cfg.LocalOwner != "admin" {
-		t.Errorf("LocalOwner = %q", cfg.LocalOwner)
-	}
-	if cfg.LocalGroup != "staff" {
-		t.Errorf("LocalGroup = %q", cfg.LocalGroup)
-	}
-	if cfg.Prune != "-keep 0:365 -keep 30:180" {
-		t.Errorf("Prune = %q", cfg.Prune)
-	}
+        cfg := NewDefaults()
+        vals := map[string]string{
+                "DESTINATION": "/volume1/backups",
+                "FILTER":      "-e *.tmp",
+                "LOCAL_OWNER": "admin",
+                "LOCAL_GROUP": "staff",
+                "PRUNE":       "-keep 0:365 -keep 30:180",
+        }
+        if err := cfg.Apply(vals); err != nil {
+                t.Fatalf("unexpected error: %v", err)
+        }
+        if cfg.Destination != "/volume1/backups" {
+                t.Errorf("Destination = %q", cfg.Destination)
+        }
+        if cfg.Filter != "-e *.tmp" {
+                t.Errorf("Filter = %q", cfg.Filter)
+        }
+        if cfg.LocalOwner != "admin" {
+                t.Errorf("LocalOwner = %q", cfg.LocalOwner)
+        }
+        if cfg.LocalGroup != "staff" {
+                t.Errorf("LocalGroup = %q", cfg.LocalGroup)
+        }
+        if cfg.Prune != "-keep 0:365 -keep 30:180" {
+                t.Errorf("Prune = %q", cfg.Prune)
+        }
 }
 
 func TestApply_EmptyMapKeepsDefaults(t *testing.T) {
-	cfg := NewDefaults()
-	if err := cfg.Apply(map[string]string{}); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cfg.LocalOwner != DefaultLocalOwner {
-		t.Errorf("LocalOwner = %q, want default %q", cfg.LocalOwner, DefaultLocalOwner)
-	}
-	if cfg.LogRetentionDays != DefaultLogRetentionDays {
-		t.Errorf("LogRetentionDays = %d, want default %d", cfg.LogRetentionDays, DefaultLogRetentionDays)
-	}
+        cfg := NewDefaults()
+        if err := cfg.Apply(map[string]string{}); err != nil {
+                t.Fatalf("unexpected error: %v", err)
+        }
+        // LocalOwner and LocalGroup are mandatory with no defaults — they should remain empty.
+        if cfg.LocalOwner != "" {
+                t.Errorf("LocalOwner = %q, want empty (no default)", cfg.LocalOwner)
+        }
+        if cfg.LocalGroup != "" {
+                t.Errorf("LocalGroup = %q, want empty (no default)", cfg.LocalGroup)
+        }
+        if cfg.LogRetentionDays != DefaultLogRetentionDays {
+                t.Errorf("LogRetentionDays = %d, want default %d", cfg.LogRetentionDays, DefaultLogRetentionDays)
+        }
 }
 
 func TestApply_InvalidThreadsNotANumber(t *testing.T) {
-	cfg := NewDefaults()
-	err := cfg.Apply(map[string]string{"THREADS": "ten"})
-	if err == nil {
-		t.Fatal("expected error for THREADS=ten, got nil")
-	}
-	if !strings.Contains(err.Error(), "THREADS") {
-		t.Errorf("error should mention THREADS, got: %v", err)
-	}
+        cfg := NewDefaults()
+        err := cfg.Apply(map[string]string{"THREADS": "ten"})
+        if err == nil {
+                t.Fatal("expected error for THREADS=ten, got nil")
+        }
+        if !strings.Contains(err.Error(), "THREADS") {
+                t.Errorf("error should mention THREADS, got: %v", err)
+        }
 }
 
 func TestApply_NegativeLogRetention(t *testing.T) {
-	cfg := NewDefaults()
-	err := cfg.Apply(map[string]string{"LOG_RETENTION_DAYS": "-5"})
-	if err == nil {
-		t.Fatal("expected error for negative LOG_RETENTION_DAYS, got nil")
-	}
-	if !strings.Contains(err.Error(), "LOG_RETENTION_DAYS") {
-		t.Errorf("error should mention LOG_RETENTION_DAYS, got: %v", err)
-	}
+        cfg := NewDefaults()
+        err := cfg.Apply(map[string]string{"LOG_RETENTION_DAYS": "-5"})
+        if err == nil {
+                t.Fatal("expected error for negative LOG_RETENTION_DAYS, got nil")
+        }
+        if !strings.Contains(err.Error(), "LOG_RETENTION_DAYS") {
+                t.Errorf("error should mention LOG_RETENTION_DAYS, got: %v", err)
+        }
 }
 
 func TestApply_InvalidPruneDeleteCount(t *testing.T) {
-	cfg := NewDefaults()
-	err := cfg.Apply(map[string]string{"SAFE_PRUNE_MAX_DELETE_COUNT": "abc"})
-	if err == nil {
-		t.Fatal("expected error for non-numeric SAFE_PRUNE_MAX_DELETE_COUNT, got nil")
-	}
-	if !strings.Contains(err.Error(), "SAFE_PRUNE_MAX_DELETE_COUNT") {
-		t.Errorf("error should mention SAFE_PRUNE_MAX_DELETE_COUNT, got: %v", err)
-	}
+        cfg := NewDefaults()
+        err := cfg.Apply(map[string]string{"SAFE_PRUNE_MAX_DELETE_COUNT": "abc"})
+        if err == nil {
+                t.Fatal("expected error for non-numeric SAFE_PRUNE_MAX_DELETE_COUNT, got nil")
+        }
+        if !strings.Contains(err.Error(), "SAFE_PRUNE_MAX_DELETE_COUNT") {
+                t.Errorf("error should mention SAFE_PRUNE_MAX_DELETE_COUNT, got: %v", err)
+        }
 }
 
 func TestApply_InvalidPruneDeletePercent(t *testing.T) {
-	cfg := NewDefaults()
-	err := cfg.Apply(map[string]string{"SAFE_PRUNE_MAX_DELETE_PERCENT": "50%"})
-	if err == nil {
-		t.Fatal("expected error for SAFE_PRUNE_MAX_DELETE_PERCENT=50%, got nil")
-	}
+        cfg := NewDefaults()
+        err := cfg.Apply(map[string]string{"SAFE_PRUNE_MAX_DELETE_PERCENT": "50%"})
+        if err == nil {
+                t.Fatal("expected error for SAFE_PRUNE_MAX_DELETE_PERCENT=50%, got nil")
+        }
 }
 
 func TestApply_InvalidMinTotalForPercent(t *testing.T) {
-	cfg := NewDefaults()
-	err := cfg.Apply(map[string]string{"SAFE_PRUNE_MIN_TOTAL_FOR_PERCENT": "nope"})
-	if err == nil {
-		t.Fatal("expected error for invalid SAFE_PRUNE_MIN_TOTAL_FOR_PERCENT")
-	}
+        cfg := NewDefaults()
+        err := cfg.Apply(map[string]string{"SAFE_PRUNE_MIN_TOTAL_FOR_PERCENT": "nope"})
+        if err == nil {
+                t.Fatal("expected error for invalid SAFE_PRUNE_MIN_TOTAL_FOR_PERCENT")
+        }
 }
 
 func TestApply_EmptyNumericValue(t *testing.T) {
-	cfg := NewDefaults()
-	err := cfg.Apply(map[string]string{"THREADS": ""})
-	if err == nil {
-		t.Fatal("expected error for empty THREADS value, got nil")
-	}
+        cfg := NewDefaults()
+        err := cfg.Apply(map[string]string{"THREADS": ""})
+        if err == nil {
+                t.Fatal("expected error for empty THREADS value, got nil")
+        }
 }
 
 // ─── NewDefaults tests ───────────────────────────────────────────────────────
 
 func TestNewDefaults(t *testing.T) {
-	cfg := NewDefaults()
-	if cfg.LocalOwner != DefaultLocalOwner {
-		t.Errorf("LocalOwner = %q, want %q", cfg.LocalOwner, DefaultLocalOwner)
-	}
-	if cfg.LocalGroup != DefaultLocalGroup {
-		t.Errorf("LocalGroup = %q, want %q", cfg.LocalGroup, DefaultLocalGroup)
-	}
-	if cfg.LogRetentionDays != DefaultLogRetentionDays {
-		t.Errorf("LogRetentionDays = %d, want %d", cfg.LogRetentionDays, DefaultLogRetentionDays)
-	}
-	if cfg.SafePruneMaxDeletePercent != DefaultSafePruneMaxDeletePercent {
-		t.Errorf("SafePruneMaxDeletePercent = %d, want %d", cfg.SafePruneMaxDeletePercent, DefaultSafePruneMaxDeletePercent)
-	}
-	if cfg.SafePruneMaxDeleteCount != DefaultSafePruneMaxDeleteCount {
-		t.Errorf("SafePruneMaxDeleteCount = %d, want %d", cfg.SafePruneMaxDeleteCount, DefaultSafePruneMaxDeleteCount)
-	}
-	if cfg.SafePruneMinTotalForPercent != DefaultSafePruneMinTotalForPercent {
-		t.Errorf("SafePruneMinTotalForPercent = %d, want %d", cfg.SafePruneMinTotalForPercent, DefaultSafePruneMinTotalForPercent)
-	}
+        cfg := NewDefaults()
+        // LocalOwner and LocalGroup are mandatory — no defaults.
+        if cfg.LocalOwner != "" {
+                t.Errorf("LocalOwner = %q, want empty (mandatory, no default)", cfg.LocalOwner)
+        }
+        if cfg.LocalGroup != "" {
+                t.Errorf("LocalGroup = %q, want empty (mandatory, no default)", cfg.LocalGroup)
+        }
+        if cfg.LogRetentionDays != DefaultLogRetentionDays {
+                t.Errorf("LogRetentionDays = %d, want %d", cfg.LogRetentionDays, DefaultLogRetentionDays)
+        }
+        if cfg.SafePruneMaxDeletePercent != DefaultSafePruneMaxDeletePercent {
+                t.Errorf("SafePruneMaxDeletePercent = %d, want %d", cfg.SafePruneMaxDeletePercent, DefaultSafePruneMaxDeletePercent)
+        }
+        if cfg.SafePruneMaxDeleteCount != DefaultSafePruneMaxDeleteCount {
+                t.Errorf("SafePruneMaxDeleteCount = %d, want %d", cfg.SafePruneMaxDeleteCount, DefaultSafePruneMaxDeleteCount)
+        }
+        if cfg.SafePruneMinTotalForPercent != DefaultSafePruneMinTotalForPercent {
+                t.Errorf("SafePruneMinTotalForPercent = %d, want %d", cfg.SafePruneMinTotalForPercent, DefaultSafePruneMinTotalForPercent)
+        }
+}
+
+// ─── ValidateOwnerGroup mandatory tests ──────────────────────────────────────
+
+func TestValidateOwnerGroup_MissingOwnerReturnsError(t *testing.T) {
+        cfg := &Config{LocalOwner: "", LocalGroup: "users"}
+        err := cfg.ValidateOwnerGroup()
+        if err == nil {
+                t.Fatal("expected error for missing LOCAL_OWNER")
+        }
+        if !strings.Contains(err.Error(), "LOCAL_OWNER is mandatory") {
+                t.Errorf("error should mention mandatory, got: %v", err)
+        }
+}
+
+func TestValidateOwnerGroup_MissingGroupReturnsError(t *testing.T) {
+        cfg := &Config{LocalOwner: "admin", LocalGroup: ""}
+        err := cfg.ValidateOwnerGroup()
+        if err == nil {
+                t.Fatal("expected error for missing LOCAL_GROUP")
+        }
+        if !strings.Contains(err.Error(), "LOCAL_GROUP is mandatory") {
+                t.Errorf("error should mention mandatory, got: %v", err)
+        }
 }
 
 // ─── ValidateRequired tests ──────────────────────────────────────────────────
 
 func TestValidateRequired_AllPresent(t *testing.T) {
-	cfg := &Config{Destination: "/vol", Threads: 4, Prune: "-keep 0:30"}
-	if err := cfg.ValidateRequired(true, true); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+        cfg := &Config{Destination: "/vol", Threads: 4, Prune: "-keep 0:30"}
+        if err := cfg.ValidateRequired(true, true); err != nil {
+                t.Errorf("unexpected error: %v", err)
+        }
 }
 
 func TestValidateRequired_MissingDestination(t *testing.T) {
-	cfg := &Config{Threads: 4, Prune: "-keep 0:30"}
-	err := cfg.ValidateRequired(true, true)
-	if err == nil {
-		t.Fatal("expected error for missing DESTINATION")
-	}
-	if !strings.Contains(err.Error(), "DESTINATION") {
-		t.Errorf("error should mention DESTINATION, got: %v", err)
-	}
+        cfg := &Config{Threads: 4, Prune: "-keep 0:30"}
+        err := cfg.ValidateRequired(true, true)
+        if err == nil {
+                t.Fatal("expected error for missing DESTINATION")
+        }
+        if !strings.Contains(err.Error(), "DESTINATION") {
+                t.Errorf("error should mention DESTINATION, got: %v", err)
+        }
 }
 
 func TestValidateRequired_MissingThreadsOnlyWhenBackup(t *testing.T) {
-	cfg := &Config{Destination: "/vol", Prune: "-keep 0:30"}
-	// No backup → threads not required
-	if err := cfg.ValidateRequired(false, true); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	// With backup → threads required
-	err := cfg.ValidateRequired(true, true)
-	if err == nil {
-		t.Fatal("expected error for missing THREADS with backup")
-	}
-	if !strings.Contains(err.Error(), "THREADS") {
-		t.Errorf("error should mention THREADS, got: %v", err)
-	}
+        cfg := &Config{Destination: "/vol", Prune: "-keep 0:30"}
+        // No backup → threads not required
+        if err := cfg.ValidateRequired(false, true); err != nil {
+                t.Errorf("unexpected error: %v", err)
+        }
+        // With backup → threads required
+        err := cfg.ValidateRequired(true, true)
+        if err == nil {
+                t.Fatal("expected error for missing THREADS with backup")
+        }
+        if !strings.Contains(err.Error(), "THREADS") {
+                t.Errorf("error should mention THREADS, got: %v", err)
+        }
 }
 
 func TestValidateRequired_MissingPruneOnlyWhenPrune(t *testing.T) {
-	cfg := &Config{Destination: "/vol", Threads: 4}
-	if err := cfg.ValidateRequired(true, false); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	err := cfg.ValidateRequired(true, true)
-	if err == nil {
-		t.Fatal("expected error for missing PRUNE with prune enabled")
-	}
-	if !strings.Contains(err.Error(), "PRUNE") {
-		t.Errorf("error should mention PRUNE, got: %v", err)
-	}
+        cfg := &Config{Destination: "/vol", Threads: 4}
+        if err := cfg.ValidateRequired(true, false); err != nil {
+                t.Errorf("unexpected error: %v", err)
+        }
+        err := cfg.ValidateRequired(true, true)
+        if err == nil {
+                t.Fatal("expected error for missing PRUNE with prune enabled")
+        }
+        if !strings.Contains(err.Error(), "PRUNE") {
+                t.Errorf("error should mention PRUNE, got: %v", err)
+        }
 }
 
 // ─── ValidateThresholds tests ────────────────────────────────────────────────
 
 func TestValidateThresholds_Valid(t *testing.T) {
-	cfg := NewDefaults()
-	if err := cfg.ValidateThresholds(); err != nil {
-		t.Errorf("unexpected error with defaults: %v", err)
-	}
+        cfg := NewDefaults()
+        if err := cfg.ValidateThresholds(); err != nil {
+                t.Errorf("unexpected error with defaults: %v", err)
+        }
 }
 
 func TestValidateThresholds_PercentTooHigh(t *testing.T) {
-	cfg := NewDefaults()
-	cfg.SafePruneMaxDeletePercent = 101
-	if err := cfg.ValidateThresholds(); err == nil {
-		t.Fatal("expected error for percent > 100")
-	}
+        cfg := NewDefaults()
+        cfg.SafePruneMaxDeletePercent = 101
+        if err := cfg.ValidateThresholds(); err == nil {
+                t.Fatal("expected error for percent > 100")
+        }
 }
 
 func TestValidateThresholds_NegativeCount(t *testing.T) {
-	cfg := NewDefaults()
-	cfg.SafePruneMaxDeleteCount = -1
-	if err := cfg.ValidateThresholds(); err == nil {
-		t.Fatal("expected error for negative count")
-	}
+        cfg := NewDefaults()
+        cfg.SafePruneMaxDeleteCount = -1
+        if err := cfg.ValidateThresholds(); err == nil {
+                t.Fatal("expected error for negative count")
+        }
 }
 
 func TestValidateThresholds_NegativeMinTotal(t *testing.T) {
-	cfg := NewDefaults()
-	cfg.SafePruneMinTotalForPercent = -1
-	if err := cfg.ValidateThresholds(); err == nil {
-		t.Fatal("expected error for negative min total")
-	}
+        cfg := NewDefaults()
+        cfg.SafePruneMinTotalForPercent = -1
+        if err := cfg.ValidateThresholds(); err == nil {
+                t.Fatal("expected error for negative min total")
+        }
 }
 
 func TestValidateThresholds_NegativeLogRetention(t *testing.T) {
-	cfg := NewDefaults()
-	cfg.LogRetentionDays = -1
-	if err := cfg.ValidateThresholds(); err == nil {
-		t.Fatal("expected error for negative log retention")
-	}
+        cfg := NewDefaults()
+        cfg.LogRetentionDays = -1
+        if err := cfg.ValidateThresholds(); err == nil {
+                t.Fatal("expected error for negative log retention")
+        }
 }
 
 func TestValidateThresholds_ZeroValues(t *testing.T) {
-	cfg := &Config{}
-	if err := cfg.ValidateThresholds(); err != nil {
-		t.Errorf("zero values should be valid: %v", err)
-	}
+        cfg := &Config{}
+        if err := cfg.ValidateThresholds(); err != nil {
+                t.Errorf("zero values should be valid: %v", err)
+        }
 }
 
 // ─── ValidateOwnerGroup tests ────────────────────────────────────────────────
 
 func TestValidateOwnerGroup_Valid(t *testing.T) {
-	cfg := &Config{LocalOwner: "admin", LocalGroup: "users"}
-	if err := cfg.ValidateOwnerGroup(); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+        cfg := &Config{LocalOwner: "admin", LocalGroup: "users"}
+        if err := cfg.ValidateOwnerGroup(); err != nil {
+                t.Errorf("unexpected error: %v", err)
+        }
 }
 
 func TestValidateOwnerGroup_InvalidOwner(t *testing.T) {
-	cfg := &Config{LocalOwner: "admin/bad", LocalGroup: "users"}
-	if err := cfg.ValidateOwnerGroup(); err == nil {
-		t.Fatal("expected error for invalid owner")
-	}
+        cfg := &Config{LocalOwner: "admin/bad", LocalGroup: "users"}
+        if err := cfg.ValidateOwnerGroup(); err == nil {
+                t.Fatal("expected error for invalid owner")
+        }
 }
 
 func TestValidateOwnerGroup_InvalidGroup(t *testing.T) {
-	cfg := &Config{LocalOwner: "admin", LocalGroup: "us ers"}
-	if err := cfg.ValidateOwnerGroup(); err == nil {
-		t.Fatal("expected error for invalid group")
-	}
+        cfg := &Config{LocalOwner: "admin", LocalGroup: "us ers"}
+        if err := cfg.ValidateOwnerGroup(); err == nil {
+                t.Fatal("expected error for invalid group")
+        }
 }
 
 func TestValidateOwnerGroup_EmptyOwner(t *testing.T) {
-	cfg := &Config{LocalOwner: "", LocalGroup: "users"}
-	if err := cfg.ValidateOwnerGroup(); err == nil {
-		t.Fatal("expected error for empty owner")
-	}
+        cfg := &Config{LocalOwner: "", LocalGroup: "users"}
+        err := cfg.ValidateOwnerGroup()
+        if err == nil {
+                t.Fatal("expected error for empty owner")
+        }
+        if !strings.Contains(err.Error(), "mandatory") {
+                t.Errorf("error should mention mandatory, got: %v", err)
+        }
 }
 
 // ─── ValidateThreads tests ──────────────────────────────────────────────────
 
 func TestValidateThreads_Valid(t *testing.T) {
-	for _, n := range []int{1, 2, 4, 8, 16} {
-		cfg := &Config{Threads: n}
-		if err := cfg.ValidateThreads(); err != nil {
-			t.Errorf("ValidateThreads(%d) unexpected error: %v", n, err)
-		}
-	}
+        for _, n := range []int{1, 2, 4, 8, 16} {
+                cfg := &Config{Threads: n}
+                if err := cfg.ValidateThreads(); err != nil {
+                        t.Errorf("ValidateThreads(%d) unexpected error: %v", n, err)
+                }
+        }
 }
 
 func TestValidateThreads_Invalid(t *testing.T) {
-	for _, n := range []int{0, -1, 3, 5, 6, 7, 9, 17, 32} {
-		cfg := &Config{Threads: n}
-		if err := cfg.ValidateThreads(); err == nil {
-			t.Errorf("ValidateThreads(%d) expected error, got nil", n)
-		}
-	}
+        for _, n := range []int{0, -1, 3, 5, 6, 7, 9, 17, 32} {
+                cfg := &Config{Threads: n}
+                if err := cfg.ValidateThreads(); err == nil {
+                        t.Errorf("ValidateThreads(%d) expected error, got nil", n)
+                }
+        }
 }
 
 // ─── BuildPruneArgs tests ───────────────────────────────────────────────────
 
 func TestBuildPruneArgs_NonEmpty(t *testing.T) {
-	cfg := &Config{Prune: "-keep 0:365 -keep 30:180"}
-	cfg.BuildPruneArgs()
-	expected := []string{"-keep", "0:365", "-keep", "30:180"}
-	if len(cfg.PruneArgs) != len(expected) {
-		t.Fatalf("PruneArgs len = %d, want %d", len(cfg.PruneArgs), len(expected))
-	}
-	for i, a := range cfg.PruneArgs {
-		if a != expected[i] {
-			t.Errorf("PruneArgs[%d] = %q, want %q", i, a, expected[i])
-		}
-	}
+        cfg := &Config{Prune: "-keep 0:365 -keep 30:180"}
+        cfg.BuildPruneArgs()
+        expected := []string{"-keep", "0:365", "-keep", "30:180"}
+        if len(cfg.PruneArgs) != len(expected) {
+                t.Fatalf("PruneArgs len = %d, want %d", len(cfg.PruneArgs), len(expected))
+        }
+        for i, a := range cfg.PruneArgs {
+                if a != expected[i] {
+                        t.Errorf("PruneArgs[%d] = %q, want %q", i, a, expected[i])
+                }
+        }
 }
 
 func TestBuildPruneArgs_Empty(t *testing.T) {
-	cfg := &Config{Prune: ""}
-	cfg.BuildPruneArgs()
-	if cfg.PruneArgs != nil {
-		t.Errorf("PruneArgs = %v, want nil", cfg.PruneArgs)
-	}
+        cfg := &Config{Prune: ""}
+        cfg.BuildPruneArgs()
+        if cfg.PruneArgs != nil {
+                t.Errorf("PruneArgs = %v, want nil", cfg.PruneArgs)
+        }
 }
 
 // ─── strictAtoi tests ───────────────────────────────────────────────────────
 
 func TestStrictAtoi_Valid(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected int
-	}{
-		{"0", 0},
-		{"1", 1},
-		{"42", 42},
-		{"100", 100},
-		{"9999", 9999},
-	}
-	for _, tt := range tests {
-		n, err := strictAtoi(tt.input)
-		if err != nil {
-			t.Errorf("strictAtoi(%q) unexpected error: %v", tt.input, err)
-		}
-		if n != tt.expected {
-			t.Errorf("strictAtoi(%q) = %d, want %d", tt.input, n, tt.expected)
-		}
-	}
+        tests := []struct {
+                input    string
+                expected int
+        }{
+                {"0", 0},
+                {"1", 1},
+                {"42", 42},
+                {"100", 100},
+                {"9999", 9999},
+        }
+        for _, tt := range tests {
+                n, err := strictAtoi(tt.input)
+                if err != nil {
+                        t.Errorf("strictAtoi(%q) unexpected error: %v", tt.input, err)
+                }
+                if n != tt.expected {
+                        t.Errorf("strictAtoi(%q) = %d, want %d", tt.input, n, tt.expected)
+                }
+        }
 }
 
 func TestStrictAtoi_Invalid(t *testing.T) {
-	invalids := []string{
-		"", "abc", "ten", "-1", "-100", "3.14", "12abc", "1 2", " 5", "5 ",
-	}
-	for _, s := range invalids {
-		_, err := strictAtoi(s)
-		if err == nil {
-			t.Errorf("strictAtoi(%q) expected error, got nil", s)
-		}
-	}
+        invalids := []string{
+                "", "abc", "ten", "-1", "-100", "3.14", "12abc", "1 2", " 5", "5 ",
+        }
+        for _, s := range invalids {
+                _, err := strictAtoi(s)
+                if err == nil {
+                        t.Errorf("strictAtoi(%q) expected error, got nil", s)
+                }
+        }
 }
 
 func TestStrictAtoi_LeadingZeros(t *testing.T) {
-	// Leading zeros should be accepted (parsed as decimal)
-	n, err := strictAtoi("007")
-	if err != nil {
-		t.Fatalf("strictAtoi(\"007\") unexpected error: %v", err)
-	}
-	if n != 7 {
-		t.Errorf("strictAtoi(\"007\") = %d, want 7", n)
-	}
+        // Leading zeros should be accepted (parsed as decimal)
+        n, err := strictAtoi("007")
+        if err != nil {
+                t.Fatalf("strictAtoi(\"007\") unexpected error: %v", err)
+        }
+        if n != 7 {
+                t.Errorf("strictAtoi(\"007\") = %d, want 7", n)
+        }
 }


### PR DESCRIPTION
## Release v1.2.0 Preparation

Updates version from v1.0.0 to v1.2.0 (current release is v1.1.1).

### Changes included in this release:

#### Added
- MIT LICENSE file
- `--version` flag to display version and build time
- CHANGELOG.md for tracking releases
- Mandatory validation for `LOCAL_OWNER` and `LOCAL_GROUP` configuration fields
- New tests for mandatory owner/group validation

#### Changed (Breaking)
- **`LOCAL_OWNER` and `LOCAL_GROUP` are now mandatory** configuration fields. They no longer have default values. Every `.conf` file must explicitly set both fields to a non-root user/group for security.
- Updated example configuration and README documentation

#### Fixed
- Cleanup logic bug: `defer doCleanup(exitCode)` captured exit code by value (always 0); replaced with closure
- Version flag: declared `version` and `buildTime` variables for proper `ldflags` injection

#### Removed
- `DefaultLocalOwner` and `DefaultLocalGroup` constants

---

> **Note:** The new branch `release/v1.2.0-prep` contains the updated version references. Please review and merge from there.