### PR TITLE
fix: use temp dir for logDir in tests to avoid /var/log permission errors in CI

### DIFF
--- a/cmd/duplicacy-backup/main.go
+++ b/cmd/duplicacy-backup/main.go
@@ -70,10 +70,15 @@ var (
 
 const (
 	rootVolume = "/volume1"
-	logDir     = "/var/log"
 	lockParent = "/var/lock"
 	scriptName = "duplicacy-backup"
 )
+
+// logDir is the directory where log files are written.
+// It defaults to /var/log for production use on Synology NAS devices.
+// Tests override this variable to use a temporary directory so that
+// the test suite does not require root/elevated permissions.
+var logDir = "/var/log"
 
 // labelPattern restricts backup labels to safe characters only.
 // This prevents path traversal attacks since labels are interpolated into

--- a/cmd/duplicacy-backup/main_test.go
+++ b/cmd/duplicacy-backup/main_test.go
@@ -16,6 +16,22 @@ import (
 	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/secrets"
 )
 
+// TestMain overrides the package-level logDir variable so that tests
+// that call initLogger() (which writes to logDir) do not require
+// write access to /var/log.  This allows the full test suite to pass
+// in CI environments and on developer machines without root privileges.
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "duplicacy-backup-test-logs-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create temp log dir: %v\n", err)
+		os.Exit(1)
+	}
+	logDir = tmp
+	code := m.Run()
+	os.RemoveAll(tmp)
+	os.Exit(code)
+}
+
 // ─── Helper: create a test logger that writes to a temp dir ──────────────────
 
 func testLogger(t *testing.T) *logger.Logger {


### PR DESCRIPTION
## Problem

Tests fail in GitHub Actions CI with:
```
Failed to initialise logger: failed to open log file /var/log/duplicacy-backup-20260409.log: permission denied
```

The CI runner doesn't have write access to `/var/log`, causing `initLogger()` to fail. While the affected tests had `t.Skip` guards, the hard-coded `const logDir = "/var/log"` made it impossible to test `initLogger` properly in non-root environments.

## Solution

**Two minimal changes:**

1. **`main.go`**: Change `logDir` from `const` to `var` so it can be overridden in tests. The production default (`/var/log`) is unchanged.

2. **`main_test.go`**: Add a `TestMain` function that sets `logDir` to a temporary directory before running any tests. The temp dir is cleaned up after all tests complete.

This allows:
- `TestApp_InitLogger_Success` and `TestApp_InitLogger_SetsLogField` to run fully (no more skipping)
- `TestIntegration_FullInitFlow` to exercise the real `initLogger` code path
- All tests to pass without root/elevated permissions

## No workflow changes needed

The existing `build.yml` is correct — only the Go source needed fixing.