### PR TITLE
refactor: add function-variable seams and runWithArgs for full-pipeline testability

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Use `--force-prune` to override these thresholds when needed.
 
 ### Coordinator Pattern
 
-The program follows a **coordinator pattern** centred on the `app` struct in `cmd/duplicacy-backup/main.go`. The top-level `run()` function creates an `*app` via `newApp()`, then calls a series of clearly-bounded methods in sequence:
+The program follows a **coordinator pattern** centred on the `app` struct in `cmd/duplicacy-backup/main.go`. The top-level `run()` function delegates to `runWithArgs(cliArgs())`, which creates an `*app` via `newApp()`, then calls a series of clearly-bounded methods in sequence:
 
 ```
 newApp → acquireLock → loadConfig → loadSecrets → printHeader → printSummary → execute → cleanup
@@ -425,7 +425,7 @@ See [MESSAGE_STYLE_GUIDE.md](MESSAGE_STYLE_GUIDE.md) for the message formatting 
 - **`run()` readable in one screen** — the entire orchestration is visible at a glance
 - **Single concern per phase** — each method does one thing
 - **Output ownership** — internal packages return data; the coordinator formats all user-facing messages
-- **Testable** — unit tests can construct an `*app` with stubbed fields and inject a `MockRunner` for command isolation
+- **Testable** — unit tests can construct an `*app` with stubbed fields, inject a `MockRunner` for command isolation, and swap package-level function variables (`geteuid`, `lookPath`, `newLock`) to test the full coordinator pipeline via `runWithArgs()`
 - **Structured errors** — typed errors with context enable precise error handling at the coordinator level
 
 ---

--- a/TESTING.md
+++ b/TESTING.md
@@ -12,9 +12,9 @@ the coordinator (`cmd/duplicacy-backup`) has both unit tests
 
 | Metric | Value |
 |--------|-------|
-| Total tests passing | **480** |
+| Total tests passing | **487** |
 | Skipped tests | 5 (environment-specific, see below) |
-| Overall statement coverage | **87.5 %** |
+| Overall statement coverage | **90.1 %** |
 
 ## Quick Start
 
@@ -49,7 +49,7 @@ go test ./cmd/duplicacy-backup/... -run TestApp_RunPrunePhase -v
 
 | Package | Test File(s) | Tests | Coverage | Focus |
 |---------|-------------|------:|--------:|-------|
-| `cmd/duplicacy-backup` | `main_test.go`, `integration_test.go` | 167 | 78.3 % | Coordinator logic, flag parsing, phase execution, end-to-end flows |
+| `cmd/duplicacy-backup` | `main_test.go`, `integration_test.go` | 173 | 83.7 % | Coordinator logic, flag parsing, phase execution, end-to-end flows |
 | `internal/btrfs` | `btrfs_test.go` | 12 | 100 % | Snapshot create/delete, volume checks |
 | `internal/config` | `config_test.go` | 66 | 99.3 % | INI parsing, defaults, validation |
 | `internal/duplicacy` | `duplicacy_test.go` | 53 | 92.2 % | Duplicacy CLI wrapper, prune preview |
@@ -58,7 +58,7 @@ go test ./cmd/duplicacy-backup/... -run TestApp_RunPrunePhase -v
 | `internal/lock` | `lock_test.go` | 20 | 92.6 % | Directory-based locking |
 | `internal/logger` | `logger_test.go` | 43 | 93.2 % | Structured logging, file output, colours |
 | `internal/permissions` | `permissions_test.go` | 8 | 100 % | chown/chmod operations |
-| `internal/secrets` | `secrets_test.go` | 47 | 86.4 % | Secrets parsing, file validation, masking |
+| `internal/secrets` | `secrets_test.go` | 48 | 88.1 % | Secrets parsing, file validation, masking |
 
 ## Testing Patterns
 
@@ -81,6 +81,21 @@ mock := execpkg.NewMockRunner(
 Each `Invocation` records `Cmd`, `Args`, and `Dir` (the working directory
 for `RunInDir` calls), so tests can assert both the commands issued and
 where they were executed.
+
+### captureOutput() Helper
+
+The `captureOutput(t, fn)` helper in `main_test.go` redirects `os.Stdout`
+and `os.Stderr` to pipes, runs the provided function, then returns the
+captured output as strings. This is used by the `TestRunWithArgs_*` tests
+to suppress and inspect output from the full coordinator pipeline:
+
+```go
+_, stderr := captureOutput(t, func() {
+    code := runWithArgs([]string{"--fix-perms", "--config-dir", configDir, "homes"})
+    // assert on code
+})
+// assert on stderr content
+```
 
 ### testApp() Helper (unit tests)
 
@@ -153,6 +168,46 @@ content := readLogFile(t, logPath)
 
 ## Key Test Approaches
 
+### Function-Variable Seams and `runWithArgs`
+
+The coordinator (`main.go`) uses **package-level function variables** as
+test seams for dependencies that cannot be injected through the `app`
+struct:
+
+| Variable | Production value | What it enables |
+|----------|-----------------|-----------------|
+| `cliArgs` | `func() []string { return os.Args[1:] }` | Decouple argument source from `os.Args` |
+| `geteuid` | `os.Geteuid` | Simulate non-root / root in tests |
+| `lookPath` | `exec.LookPath` | Stub binary-existence checks |
+| `newLock` | `lock.New` | Redirect lock directory to temp dirs |
+
+The `run()` function delegates to `runWithArgs(args)`, which accepts an
+explicit argument slice. This allows tests to exercise the **full
+coordinator pipeline** (argument parsing → validation → config loading →
+lock acquisition → error translation) without manipulating `os.Args`:
+
+```go
+// Test that --help exits cleanly through the full pipeline
+captureOutput(t, func() {
+    if code := runWithArgs([]string{"--help"}); code != 0 {
+        t.Errorf("want 0, got %d", code)
+    }
+})
+```
+
+Tests swap the function variables, call `runWithArgs`, and restore the
+originals via `defer`:
+
+```go
+oldGeteuid := geteuid
+geteuid = func() int { return 1000 }  // simulate non-root
+defer func() { geteuid = oldGeteuid }()
+```
+
+Six `TestRunWithArgs_*` tests cover: `--help`, `--version`, invalid
+flags, non-root rejection, config-load failure (with error message
+assertion), and lock-acquisition failure.
+
 ### Symlink Normalisation in Runner Tests
 
 `TestCommandRunner_RunInDir_SetsWorkingDirectory` verifies that `RunInDir`
@@ -212,14 +267,15 @@ paths. This is expected and keeps CI green without privileged containers.
 | BTRFS | `MockRunner` | subvolume snapshot, delete, show |
 | Permissions | `MockRunner` | chown, chmod via find |
 | Lock | Real filesystem | mkdir-based directory locks (temp dirs) |
-| Secrets | Real filesystem | temp files with controlled permissions |
+| Secrets (file access) | Real filesystem | temp files with controlled permissions |
+| Secrets (parser) | `io.Reader` | `strings.NewReader`, `errReader` for I/O errors |
 | Config | Real filesystem | temp INI files |
 
 ## Coverage Summary (v1.8.2, April 2026)
 
 | Package | Coverage |
 |---------|--------:|
-| `cmd/duplicacy-backup` | 78.3 % |
+| `cmd/duplicacy-backup` | 83.7 % |
 | `internal/btrfs` | 100.0 % |
 | `internal/config` | 99.3 % |
 | `internal/duplicacy` | 92.2 % |
@@ -228,17 +284,17 @@ paths. This is expected and keeps CI green without privileged containers.
 | `internal/lock` | 92.6 % |
 | `internal/logger` | 93.2 % |
 | `internal/permissions` | 100.0 % |
-| `internal/secrets` | 86.4 % |
-| **Total** | **87.5 %** |
+| `internal/secrets` | 88.1 % |
+| **Total** | **90.1 %** |
 
 ### Notable Coverage Improvements (v1.8.x)
 
 | Area | Before | After | Key change |
 |------|-------:|------:|------------|
-| Secrets | ~50 % | 86.4 % | ParseSecrets/ValidateFileAccess split |
+| Secrets | ~50 % | 88.1 % | ParseSecrets/ValidateFileAccess split; errReader test |
 | Logger | 14.8 % | 93.2 % | Rewrote test suite with 43 tests |
-| Coordinator | 52.6 % | 78.3 % | Added integration tests via itestApp |
-| **Overall** | **~66 %** | **87.5 %** | |
+| Coordinator | 52.6 % | 83.7 % | Added integration tests via itestApp; runWithArgs seam tests |
+| **Overall** | **~66 %** | **90.1 %** | |
 
 ## Testing Philosophy
 

--- a/cmd/duplicacy-backup/main.go
+++ b/cmd/duplicacy-backup/main.go
@@ -68,6 +68,11 @@ var (
 	buildTime = "unknown"
 )
 
+var cliArgs = func() []string { return os.Args[1:] }
+var geteuid = os.Geteuid
+var lookPath = exec.LookPath
+var newLock = lock.New
+
 const (
 	rootVolume = "/volume1"
 	lockParent = "/var/lock"
@@ -162,7 +167,11 @@ const exitHandled = -1
 // method in order, and translates errors into a numeric exit code.  The
 // entire flow is visible in one screen.
 func run() int {
-	a, code := newApp(os.Args[1:])
+	return runWithArgs(cliArgs())
+}
+
+func runWithArgs(args []string) int {
+	a, code := newApp(args)
 	if code == exitHandled {
 		return 0 // --help / --version: handled, exit cleanly
 	}
@@ -333,7 +342,7 @@ func (a *app) parseAppFlags(args []string) int {
 // caller logs it and exits.
 func (a *app) validateEnvironment() error {
 	// Must be root
-	if os.Geteuid() != 0 {
+	if geteuid() != 0 {
 		a.log.Close()
 		return fmt.Errorf("Must be run as root.")
 	}
@@ -347,7 +356,7 @@ func (a *app) validateEnvironment() error {
 	// Check duplicacy binary – only needed for backup or prune operations.
 	// Skip for standalone --fix-perms which only calls chown/chmod.
 	if a.doBackup || a.doPrune {
-		if _, err := exec.LookPath("duplicacy"); err != nil {
+		if _, err := lookPath("duplicacy"); err != nil {
 			a.log.Close()
 			return fmt.Errorf("Required command 'duplicacy' not found")
 		}
@@ -355,7 +364,7 @@ func (a *app) validateEnvironment() error {
 
 	// Check btrfs command – only needed for backup (snapshot create/delete)
 	if a.doBackup {
-		if _, err := exec.LookPath("btrfs"); err != nil {
+		if _, err := lookPath("btrfs"); err != nil {
 			a.log.Close()
 			return fmt.Errorf("Required command 'btrfs' not found (needed for backup snapshots)")
 		}
@@ -425,7 +434,7 @@ func (a *app) derivePaths() error {
 	a.runner = execpkg.NewCommandRunner(a.log, a.flags.dryRun)
 
 	// Create the directory-based PID lock.
-	a.lk = lock.New(lockParent, a.backupLabel)
+	a.lk = newLock(lockParent, a.backupLabel)
 
 	return nil
 }

--- a/cmd/duplicacy-backup/main_test.go
+++ b/cmd/duplicacy-backup/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -66,6 +67,50 @@ func testApp(t *testing.T) *app {
 		secretsDir: t.TempDir(),
 		runner:     execpkg.NewMockRunner(),
 	}
+}
+
+func captureOutput(t *testing.T, fn func()) (string, string) {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	stderrR, stderrW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stderr pipe: %v", err)
+	}
+
+	os.Stdout = stdoutW
+	os.Stderr = stderrW
+	defer func() {
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+		stdoutR.Close()
+		stderrR.Close()
+	}()
+
+	fn()
+
+	if err := stdoutW.Close(); err != nil {
+		t.Fatalf("closing stdout writer: %v", err)
+	}
+	if err := stderrW.Close(); err != nil {
+		t.Fatalf("closing stderr writer: %v", err)
+	}
+
+	stdoutBytes, err := io.ReadAll(stdoutR)
+	if err != nil {
+		t.Fatalf("reading stdout: %v", err)
+	}
+	stderrBytes, err := io.ReadAll(stderrR)
+	if err != nil {
+		t.Fatalf("reading stderr: %v", err)
+	}
+
+	return string(stdoutBytes), string(stderrBytes)
 }
 
 // ─── Free function tests (preserved from original) ──────────────────────────
@@ -1490,6 +1535,102 @@ func TestVersionOutput_ContainsExpectedFormat(t *testing.T) {
 	}
 	if !strings.Contains(output, version) {
 		t.Errorf("version output should contain %q, got: %s", version, output)
+	}
+}
+
+func TestRunWithArgs_HelpReturnsZero(t *testing.T) {
+	captureOutput(t, func() {
+		if code := runWithArgs([]string{"--help"}); code != 0 {
+			t.Errorf("runWithArgs(--help) = %d, want 0", code)
+		}
+	})
+}
+
+func TestRunWithArgs_VersionReturnsZero(t *testing.T) {
+	captureOutput(t, func() {
+		if code := runWithArgs([]string{"--version"}); code != 0 {
+			t.Errorf("runWithArgs(--version) = %d, want 0", code)
+		}
+	})
+}
+
+func TestRunWithArgs_InvalidFlagReturnsOne(t *testing.T) {
+	captureOutput(t, func() {
+		if code := runWithArgs([]string{"--nonexistent"}); code != 1 {
+			t.Errorf("runWithArgs(--nonexistent) = %d, want 1", code)
+		}
+	})
+}
+
+func TestRunWithArgs_NonRootReturnsOne(t *testing.T) {
+	oldGeteuid := geteuid
+	geteuid = func() int { return 1000 }
+	defer func() { geteuid = oldGeteuid }()
+
+	captureOutput(t, func() {
+		if code := runWithArgs([]string{"homes"}); code != 1 {
+			t.Errorf("runWithArgs(non-root) = %d, want 1", code)
+		}
+	})
+}
+
+func TestRunWithArgs_ConfigLoadFailureReturnsTranslatedError(t *testing.T) {
+	oldGeteuid := geteuid
+	oldNewLock := newLock
+	geteuid = func() int { return 0 }
+	defer func() {
+		geteuid = oldGeteuid
+		newLock = oldNewLock
+	}()
+
+	lockDir := t.TempDir()
+	newLock = func(lockParent, label string) *lock.Lock {
+		return lock.New(lockDir, label)
+	}
+
+	configDir := t.TempDir()
+	expected := "Configuration file not found: " + filepath.Join(configDir, "homes-backup.conf") + "."
+
+	_, stderr := captureOutput(t, func() {
+		if code := runWithArgs([]string{"--fix-perms", "--config-dir", configDir, "homes"}); code != 1 {
+			t.Errorf("runWithArgs(config load failure) = %d, want 1", code)
+		}
+	})
+
+	if !strings.Contains(stderr, expected) {
+		t.Fatalf("stderr = %q, want it to contain %q", stderr, expected)
+	}
+}
+
+func TestRunWithArgs_LockAcquisitionFailureReturnsTranslatedError(t *testing.T) {
+	oldGeteuid := geteuid
+	oldNewLock := newLock
+	geteuid = func() int { return 0 }
+	defer func() {
+		geteuid = oldGeteuid
+		newLock = oldNewLock
+	}()
+
+	blockingFile := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blockingFile, []byte("x"), 0644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", blockingFile, err)
+	}
+
+	newLock = func(lockParent, label string) *lock.Lock {
+		lk := lock.New(t.TempDir(), label)
+		lk.Path = filepath.Join(blockingFile, "backup-"+label+".lock.d")
+		lk.PIDFile = filepath.Join(lk.Path, "pid")
+		return lk
+	}
+
+	_, stderr := captureOutput(t, func() {
+		if code := runWithArgs([]string{"--fix-perms", "homes"}); code != 1 {
+			t.Errorf("runWithArgs(lock acquisition failure) = %d, want 1", code)
+		}
+	})
+
+	if !strings.Contains(stderr, "Lock acquisition failed: failed to create lock parent directory") {
+		t.Fatalf("stderr = %q, want it to contain translated lock acquisition failure", stderr)
 	}
 }
 

--- a/internal/secrets/secrets_test.go
+++ b/internal/secrets/secrets_test.go
@@ -1,6 +1,7 @@
 package secrets
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,6 +37,12 @@ func validSecretContent() string {
 // isRoot reports whether the current process is running as root.
 func isRoot() bool {
 	return os.Getuid() == 0
+}
+
+type errReader struct{}
+
+func (errReader) Read(_ []byte) (int, error) {
+	return 0, errors.New("boom")
 }
 
 // ─── GetSecretsFilePath tests ───────────────────────────────────────────────
@@ -355,6 +362,16 @@ func TestLoadSecretsFile_StatError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not found") {
 		t.Errorf("error should mention not found, got: %v", err)
+	}
+}
+
+func TestParseSecrets_ReaderError(t *testing.T) {
+	_, err := ParseSecrets(errReader{}, "test.env")
+	if err == nil {
+		t.Fatal("expected reader error")
+	}
+	if !strings.Contains(err.Error(), "error reading secrets file") {
+		t.Errorf("error should mention read failure, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Introduce package-level function variables as swappable test seams in the coordinator, and split `run()` into `run()` + `runWithArgs(args)` so tests can exercise the **full coordinator pipeline** (argument parsing → validation → config loading → lock acquisition → error translation) without manipulating `os.Args`.

## Changes

### `cmd/duplicacy-backup/main.go`
- Extract four package-level function variables as test seams:
  - `cliArgs` — decouples argument source from `os.Args`
  - `geteuid` — enables simulating root/non-root in tests
  - `lookPath` — allows stubbing binary-existence checks
  - `newLock` — redirects lock directory to temp dirs in tests
- Split `run()` into `run()` + `runWithArgs(args []string)` for direct testability

### `cmd/duplicacy-backup/main_test.go`
- Add `captureOutput(t, fn)` helper that redirects stdout/stderr to pipes for inspection
- Add 6 new `TestRunWithArgs_*` tests:
  - `_HelpReturnsZero` — `--help` exits cleanly through the full pipeline
  - `_VersionReturnsZero` — `--version` exits cleanly
  - `_InvalidFlagReturnsOne` — unknown flag returns exit code 1
  - `_NonRootReturnsOne` — non-root user rejected via `geteuid` seam
  - `_ConfigLoadFailureReturnsTranslatedError` — missing config produces correct stderr
  - `_LockAcquisitionFailureReturnsTranslatedError` — lock failure produces correct stderr

### `internal/secrets/secrets_test.go`
- Add `errReader` type (returns error on `Read`)
- Add `TestParseSecrets_ReaderError` — covers the `io.Reader` error path in `ParseSecrets`

### Documentation
- **README.md**: Update architecture section to reflect `runWithArgs` delegation and function-variable seams in design goals
- **TESTING.md**: Add sections on function-variable seams, `captureOutput()` helper, and `errReader` pattern; update test counts (480 → 487) and coverage metrics (87.5% → 90.1%)

## Test Results

All **487 tests pass** (5 skipped — root-gated, as expected). Overall statement coverage: **90.1%**.

| Package | Coverage |
|---------|--------:|
| `cmd/duplicacy-backup` | 83.7% |
| `internal/secrets` | 88.1% |
| All others | unchanged |