### PR TITLE
[codex] polish workflow cleanup and docs

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -126,3 +126,7 @@ Request -> Plan -> Execute -> runWithArgs
 
 That makes failures easier to locate and lets new features land in the layer
 they actually belong to.
+
+The test split is also meant to keep `cmd/duplicacy-backup` small. As more
+workflow behavior moves under `internal/workflow`, most new coordinator tests
+should be added there unless they are specifically about the real entrypoint.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The application now follows an explicit `Request -> Plan -> Execute` flow.
+The application follows an explicit `Request -> Plan -> Execute` flow.
 
 That split keeps the entrypoint small, keeps planning non-mutating, and makes
 tests easier to write around stable boundaries instead of one large
@@ -32,8 +32,8 @@ It is responsible for:
 - validating flag combinations
 - validating the backup label
 
-The `Request` type is intentionally small. It describes what the user asked for,
-not what the application has resolved from the filesystem or config yet.
+The `Request` type is intentionally small. It describes what the user asked
+for, not what the application has resolved from the filesystem or config yet.
 
 ## Plan
 
@@ -69,6 +69,20 @@ It is responsible for:
 
 This keeps operator-facing runtime behavior in one place and makes phase order
 easy to follow.
+
+## Why This Shape
+
+The main goal of the refactor was simplicity, not framework-building.
+
+The codebase now has:
+
+- a thin entrypoint in `cmd/duplicacy-backup`
+- one orchestration package in `internal/workflow`
+- unchanged domain packages for config, secrets, btrfs, duplicacy, locking,
+  permissions, logging, and process execution
+
+That gives the application clear boundaries without over-splitting the design
+into many small packages.
 
 ## Main Packages
 

--- a/internal/workflow/plan.go
+++ b/internal/workflow/plan.go
@@ -25,7 +25,6 @@ type Plan struct {
 	ConfigFile  string
 	SecretsDir  string
 	SecretsFile string
-	LockPath    string
 
 	OperationMode string
 }

--- a/internal/workflow/planner.go
+++ b/internal/workflow/planner.go
@@ -95,7 +95,6 @@ func (p *Planner) derivePlan(req *Request) *Plan {
 		ConfigFile:     filepath.Join(configDir, fmt.Sprintf("%s-backup.conf", backupLabel)),
 		SecretsDir:     secretsDir,
 		SecretsFile:    secrets.GetSecretsFilePath(secretsDir, config.DefaultSecretsPrefix, backupLabel),
-		LockPath:       filepath.Join(p.meta.LockParent, fmt.Sprintf("backup-%s.lock.d", backupLabel)),
 	}
 }
 

--- a/internal/workflow/request.go
+++ b/internal/workflow/request.go
@@ -4,10 +4,6 @@ import (
 	"fmt"
 )
 
-// ExitHandled indicates that the request was fully handled during parsing,
-// such as --help or --version, and the process should exit cleanly.
-const ExitHandled = -1
-
 // RequestError describes a request-parsing or request-validation failure.
 // ShowUsage marks errors that should be followed by usage text.
 type RequestError struct {

--- a/internal/workflow/summary_test.go
+++ b/internal/workflow/summary_test.go
@@ -1,0 +1,88 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/config"
+	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/secrets"
+)
+
+func TestSummaryLines_FixPermsOnlyLayout(t *testing.T) {
+	plan := &Plan{
+		Request: &Request{
+			FixPerms:     true,
+			FixPermsOnly: true,
+			DryRun:       true,
+		},
+		Config: &config.Config{
+			LocalOwner: "backupuser",
+			LocalGroup: "users",
+		},
+		BackupTarget:  "/backups/homes",
+		OperationMode: "Fix permissions only",
+	}
+
+	lines := SummaryLines(plan)
+	if len(lines) != 5 {
+		t.Fatalf("len(lines) = %d, want 5", len(lines))
+	}
+
+	expected := []string{
+		"Operation Mode",
+		"Destination",
+		"Local Owner",
+		"Local Group",
+		"Dry Run",
+	}
+	for i, label := range expected {
+		if lines[i].Label != label {
+			t.Fatalf("lines[%d].Label = %q, want %q", i, lines[i].Label, label)
+		}
+	}
+}
+
+func TestSummaryLines_RemoteIncludesSecrets(t *testing.T) {
+	plan := &Plan{
+		Request: &Request{
+			Mode:       "backup",
+			DoBackup:   true,
+			RemoteMode: true,
+		},
+		Config: &config.Config{
+			Destination:                 "/backups",
+			Threads:                     4,
+			LogRetentionDays:            30,
+			SafePruneMaxDeletePercent:   10,
+			SafePruneMaxDeleteCount:     25,
+			SafePruneMinTotalForPercent: 20,
+		},
+		Secrets: &secrets.Secrets{
+			StorjS3ID:     "1234567890123456789012345678",
+			StorjS3Secret: "12345678901234567890123456789012345678901234567890123",
+		},
+		BackupLabel:    "homes",
+		SnapshotSource: "/volume1/homes",
+		RepositoryPath: "/volume1/homes-snap",
+		WorkRoot:       "/tmp/work",
+		BackupTarget:   "/backups/homes",
+		ConfigFile:     "/config/homes-backup.conf",
+		SecretsDir:     "/root/.secrets",
+		SecretsFile:    "/root/.secrets/duplicacy-homes.env",
+		OperationMode:  "Backup only",
+	}
+
+	lines := SummaryLines(plan)
+	foundSecretsFile := false
+	foundSecretsDir := false
+	for _, line := range lines {
+		if line.Label == "Secrets Dir" {
+			foundSecretsDir = true
+		}
+		if line.Label == "Secrets File" {
+			foundSecretsFile = true
+		}
+	}
+	if !foundSecretsDir || !foundSecretsFile {
+		t.Fatalf("expected secrets lines in summary, got %+v", lines)
+	}
+}


### PR DESCRIPTION
## What changed

This follow-up polishes the new Request -> Plan -> Execute refactor.

Changes:
- removed a few dead workflow leftovers
- tightened architecture and testing docs
- added summary-model test coverage in `internal/workflow/summary_test.go`

## Why

The main refactor is already in place. This PR just cleans up the remaining rough edges and improves maintainability and documentation clarity.

## Validation

- go test ./...
- go vet ./...