### PR TITLE
[codex] tighten workflow boundaries and output consistency

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -141,3 +141,21 @@ should be added there unless they are specifically about the real entrypoint.
 As the plan gets richer, new tests should prefer asserting plan fields and
 workflow translations directly instead of reconstructing execution behavior from
 raw request/config state in the `cmd` package.
+
+## Operator Message Style
+
+Operator-facing wording is owned by `internal/workflow`.
+
+Rules:
+
+- translated operator messages should be complete sentences
+- translated operator messages should end with terminal punctuation
+- domain packages should return typed errors rather than pre-formatted final wording
+- `internal/workflow/messages.go` is the translation contract for final stderr text
+
+When adding a new high-value error path, prefer:
+
+1. return a typed domain error from the package
+2. translate it in `internal/workflow/messages.go`
+3. add or update a table-driven translation test
+4. add a `runWithArgs` assertion if the message is part of the real entrypoint UX

--- a/TESTING.md
+++ b/TESTING.md
@@ -83,6 +83,7 @@ Planner tests cover:
 - backup-target derivation
 - summary precomputation
 - execution-ready plan fields
+- execution-ready command strings
 - btrfs validation during backup planning
 - minimal fix-perms-only planning
 
@@ -91,6 +92,7 @@ Executor tests cover:
 - operation-mode rendering for combined flows
 - end-to-end dry-run execution for fix-perms-only
 - lock lifecycle during execution
+- cleanup and prune-policy behavior through focused workflow helpers
 
 Workflow tests also cover:
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -81,6 +81,8 @@ Planner tests cover:
 - config loading
 - operation-mode derivation
 - backup-target derivation
+- summary precomputation
+- execution-ready plan fields
 - btrfs validation during backup planning
 - minimal fix-perms-only planning
 
@@ -89,6 +91,11 @@ Executor tests cover:
 - operation-mode rendering for combined flows
 - end-to-end dry-run execution for fix-perms-only
 - lock lifecycle during execution
+
+Workflow tests also cover:
+
+- operator-message translation
+- summary layout for fixed-perms-only and remote flows
 
 ### `internal/btrfs`
 
@@ -130,3 +137,7 @@ they actually belong to.
 The test split is also meant to keep `cmd/duplicacy-backup` small. As more
 workflow behavior moves under `internal/workflow`, most new coordinator tests
 should be added there unless they are specifically about the real entrypoint.
+
+As the plan gets richer, new tests should prefer asserting plan fields and
+workflow translations directly instead of reconstructing execution behavior from
+raw request/config state in the `cmd` package.

--- a/cmd/duplicacy-backup/main.go
+++ b/cmd/duplicacy-backup/main.go
@@ -60,7 +60,7 @@ func runWithArgs(args []string) int {
 	planner := workflow.NewPlanner(meta, rt, log, runner)
 	plan, err := planner.Build(result.Request)
 	if err != nil {
-		log.Error("%v", err)
+		log.Error("%s", workflow.OperatorMessage(err))
 		log.Close()
 		return 1
 	}
@@ -83,7 +83,7 @@ func buildRequest(args []string, meta workflow.Metadata, rt workflow.Runtime) (*
 	}
 	defer log.Close()
 
-	log.Error("%v", err)
+	log.Error("%s", workflow.OperatorMessage(err))
 	var requestErr *workflow.RequestError
 	if errors.As(err, &requestErr) && requestErr.ShowUsage {
 		fmt.Fprintln(os.Stderr)

--- a/cmd/duplicacy-backup/main_test.go
+++ b/cmd/duplicacy-backup/main_test.go
@@ -128,7 +128,7 @@ func TestRunWithArgs_InvalidFlagReturnsOne(t *testing.T) {
 				t.Fatalf("runWithArgs(--nope) = %d", code)
 			}
 		})
-		if !strings.Contains(stderr, "unknown option --nope") {
+		if !strings.Contains(stderr, "unknown option --nope.") {
 			t.Fatalf("stderr = %q", stderr)
 		}
 	})
@@ -156,7 +156,7 @@ func TestRunWithArgs_ConfigLoadFailureReturnsOne(t *testing.T) {
 				t.Fatalf("runWithArgs(config failure) = %d", code)
 			}
 		})
-		if !strings.Contains(stderr, "Configuration file not found") {
+		if !strings.Contains(stderr, "Configuration file not found:") || !strings.Contains(stderr, "homes-backup.conf.") {
 			t.Fatalf("stderr = %q", stderr)
 		}
 	})
@@ -179,7 +179,7 @@ func TestRunWithArgs_LockAcquisitionFailureReturnsOne(t *testing.T) {
 				t.Fatalf("runWithArgs(lock failure) = %d", code)
 			}
 		})
-		if !strings.Contains(stderr, "Lock acquisition failed") {
+		if !strings.Contains(stderr, "Lock acquisition failed:") || !strings.Contains(stderr, "not a directory.") {
 			t.Fatalf("stderr = %q", stderr)
 		}
 	})
@@ -197,6 +197,9 @@ func TestRunWithArgs_BackupDryRunReturnsZero(t *testing.T) {
 		if !strings.Contains(stderr, "Backup phase completed (dry-run).") {
 			t.Fatalf("stderr = %q", stderr)
 		}
+		if !strings.Contains(stderr, "All operations completed.") {
+			t.Fatalf("stderr = %q", stderr)
+		}
 	})
 }
 
@@ -211,6 +214,9 @@ func TestRunWithArgs_FixPermsOnlyDryRunReturnsZero(t *testing.T) {
 			}
 		})
 		if !strings.Contains(stderr, "Permission normalisation completed (dry-run).") {
+			t.Fatalf("stderr = %q", stderr)
+		}
+		if !strings.Contains(stderr, "All operations completed.") {
 			t.Fatalf("stderr = %q", stderr)
 		}
 	})

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,6 +54,7 @@ It is responsible for:
   - dry-run and mode flags
   - prune/filter display values
   - ownership and threshold values
+  - execution-ready command strings and cleanup inputs
 
 The important design rule is that planning does not mutate operational state.
 It can inspect the environment and run validations, but it does not acquire
@@ -76,9 +77,10 @@ It is responsible for:
 This keeps operator-facing runtime behavior in one place and makes phase order
 easy to follow.
 
-`Executor` now delegates presentation work to a small presenter and relies on
-the plan for most execution decisions rather than repeatedly reaching back into
-raw request/config data.
+`Executor` now delegates presentation work to a small presenter, cleanup to
+focused workflow helpers, and prune preview policy to dedicated workflow code.
+It relies on the plan for execution decisions rather than repeatedly reaching
+back into raw request/config data.
 
 ## Why This Shape
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,7 +47,13 @@ It is responsible for:
 - secrets loading and validation
 - backup-target derivation
 - backup-mode btrfs validation
-- summary-ready derived values such as operation mode and resolved paths
+- execution-ready derived values such as:
+  - operation mode
+  - mode display
+  - summary lines
+  - dry-run and mode flags
+  - prune/filter display values
+  - ownership and threshold values
 
 The important design rule is that planning does not mutate operational state.
 It can inspect the environment and run validations, but it does not acquire
@@ -62,13 +68,17 @@ It is responsible for:
 - signal handling
 - log cleanup
 - lock acquisition and release
-- startup header and summary output
+- runtime sequencing
 - Duplicacy working-directory setup
 - backup, prune, and fix-perms execution
 - final cleanup and result output
 
 This keeps operator-facing runtime behavior in one place and makes phase order
 easy to follow.
+
+`Executor` now delegates presentation work to a small presenter and relies on
+the plan for most execution decisions rather than repeatedly reaching back into
+raw request/config data.
 
 ## Why This Shape
 
@@ -119,5 +129,7 @@ Operator-facing output is still owned by the top-level execution layer.
 Domain packages return data or structured errors; they do not print their own
 status messages.
 
-That keeps message formatting consistent and avoids spreading user-facing tone
-across multiple packages.
+The workflow layer also owns final error translation. Internal packages can
+return rich typed errors while the workflow decides the final operator-facing
+message. That keeps message formatting consistent and avoids spreading
+user-facing tone across multiple packages.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,8 @@ import (
 	"os/user"
 	"regexp"
 	"strings"
+
+	apperrors "github.com/phillipmcmahon/synology-duplicacy-backup/internal/errors"
 )
 
 // Defaults for safe prune thresholds.
@@ -80,7 +82,7 @@ func NewDefaults() *Config {
 func ParseFile(path, targetSection string) (map[string]string, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("cannot open config file %s: %w", path, err)
+		return nil, apperrors.NewConfigError("open", fmt.Errorf("cannot open config file %s: %w", path, err), "path", path)
 	}
 	defer f.Close()
 
@@ -104,7 +106,7 @@ func ParseFile(path, targetSection string) (map[string]string, error) {
 		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
 			currentSection = line[1 : len(line)-1]
 			if seenSections[currentSection] {
-				return nil, fmt.Errorf("config file has duplicate section [%s] at line %d", currentSection, lineno)
+				return nil, apperrors.NewConfigError("parse", fmt.Errorf("config file has duplicate section [%s] at line %d", currentSection, lineno), "path", path)
 			}
 			seenSections[currentSection] = true
 			continue
@@ -112,12 +114,12 @@ func ParseFile(path, targetSection string) (map[string]string, error) {
 
 		// Must be inside a section
 		if currentSection == "" {
-			return nil, fmt.Errorf("config file has content outside a section at line %d: %s", lineno, raw)
+			return nil, apperrors.NewConfigError("parse", fmt.Errorf("config file has content outside a section at line %d: %s", lineno, raw), "path", path)
 		}
 
 		// Must contain =
 		if !strings.Contains(line, "=") {
-			return nil, fmt.Errorf("config file has invalid line at %d (expected key=value): %s", lineno, raw)
+			return nil, apperrors.NewConfigError("parse", fmt.Errorf("config file has invalid line at %d (expected key=value): %s", lineno, raw), "path", path)
 		}
 
 		parts := strings.SplitN(line, "=", 2)
@@ -125,21 +127,21 @@ func ParseFile(path, targetSection string) (map[string]string, error) {
 		value := strings.TrimSpace(parts[1])
 
 		if key == "" {
-			return nil, fmt.Errorf("config file has malformed key=value pair with missing key at line %d", lineno)
+			return nil, apperrors.NewConfigError("parse", fmt.Errorf("config file has malformed key=value pair with missing key at line %d", lineno), "path", path)
 		}
 
 		if !keyPattern.MatchString(key) {
-			return nil, fmt.Errorf("invalid config key '%s' at line %d in section [%s]", key, lineno, currentSection)
+			return nil, apperrors.NewConfigError("parse", fmt.Errorf("invalid config key '%s' at line %d in section [%s]", key, lineno, currentSection), "path", path)
 		}
 
 		if !AllowedConfigKeys[key] {
-			return nil, fmt.Errorf("config key '%s' is not permitted at line %d in section [%s]", key, lineno, currentSection)
+			return nil, apperrors.NewConfigError("parse", fmt.Errorf("config key '%s' is not permitted at line %d in section [%s]", key, lineno, currentSection), "path", path)
 		}
 
 		// LOCAL_OWNER and LOCAL_GROUP are only meaningful for local operations;
 		// reject them if they appear outside the [local] section.
 		if currentSection != "local" && LocalOnlyKeys[key] {
-			return nil, fmt.Errorf("config key '%s' at line %d is only allowed in [local] section, not [%s]", key, lineno, currentSection)
+			return nil, apperrors.NewConfigError("parse", fmt.Errorf("config key '%s' at line %d is only allowed in [local] section, not [%s]", key, lineno, currentSection), "path", path)
 		}
 
 		// Strip surrounding quotes
@@ -154,14 +156,14 @@ func ParseFile(path, targetSection string) (map[string]string, error) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("error reading config file: %w", err)
+		return nil, apperrors.NewConfigError("read", fmt.Errorf("error reading config file: %w", err), "path", path)
 	}
 
 	if !seenSections["common"] {
-		return nil, fmt.Errorf("config file %s is missing required [common] section", path)
+		return nil, apperrors.NewConfigError("section-common", fmt.Errorf("config file %s is missing required [common] section", path), "path", path)
 	}
 	if !seenSections[targetSection] {
-		return nil, fmt.Errorf("config file %s is missing required [%s] section for current mode", path, targetSection)
+		return nil, apperrors.NewConfigError("section-target", fmt.Errorf("config file %s is missing required [%s] section for current mode", path, targetSection), "path", path, "section", targetSection)
 	}
 
 	return result, nil
@@ -188,35 +190,35 @@ func (c *Config) Apply(values map[string]string) error {
 	if v, ok := values["LOG_RETENTION_DAYS"]; ok {
 		n, err := strictAtoi(v)
 		if err != nil {
-			return fmt.Errorf("LOG_RETENTION_DAYS: %w", err)
+			return apperrors.NewConfigError("log-retention-days", fmt.Errorf("LOG_RETENTION_DAYS: %w", err))
 		}
 		c.LogRetentionDays = n
 	}
 	if v, ok := values["THREADS"]; ok {
 		n, err := strictAtoi(v)
 		if err != nil {
-			return fmt.Errorf("THREADS: %w", err)
+			return apperrors.NewConfigError("threads", fmt.Errorf("THREADS: %w", err))
 		}
 		c.Threads = n
 	}
 	if v, ok := values["SAFE_PRUNE_MAX_DELETE_PERCENT"]; ok {
 		n, err := strictAtoi(v)
 		if err != nil {
-			return fmt.Errorf("SAFE_PRUNE_MAX_DELETE_PERCENT: %w", err)
+			return apperrors.NewConfigError("safe-prune-max-delete-percent", fmt.Errorf("SAFE_PRUNE_MAX_DELETE_PERCENT: %w", err))
 		}
 		c.SafePruneMaxDeletePercent = n
 	}
 	if v, ok := values["SAFE_PRUNE_MAX_DELETE_COUNT"]; ok {
 		n, err := strictAtoi(v)
 		if err != nil {
-			return fmt.Errorf("SAFE_PRUNE_MAX_DELETE_COUNT: %w", err)
+			return apperrors.NewConfigError("safe-prune-max-delete-count", fmt.Errorf("SAFE_PRUNE_MAX_DELETE_COUNT: %w", err))
 		}
 		c.SafePruneMaxDeleteCount = n
 	}
 	if v, ok := values["SAFE_PRUNE_MIN_TOTAL_FOR_PERCENT"]; ok {
 		n, err := strictAtoi(v)
 		if err != nil {
-			return fmt.Errorf("SAFE_PRUNE_MIN_TOTAL_FOR_PERCENT: %w", err)
+			return apperrors.NewConfigError("safe-prune-min-total-for-percent", fmt.Errorf("SAFE_PRUNE_MIN_TOTAL_FOR_PERCENT: %w", err))
 		}
 		c.SafePruneMinTotalForPercent = n
 	}
@@ -238,7 +240,7 @@ func (c *Config) ValidateRequired(doBackup, doPrune bool) error {
 	}
 
 	if len(missing) > 0 {
-		return fmt.Errorf("missing required config variables: %s", strings.Join(missing, ", "))
+		return apperrors.NewConfigError("required", fmt.Errorf("missing required config variables: %s", strings.Join(missing, ", ")))
 	}
 	return nil
 }
@@ -246,16 +248,16 @@ func (c *Config) ValidateRequired(doBackup, doPrune bool) error {
 // ValidateThresholds validates numeric threshold values.
 func (c *Config) ValidateThresholds() error {
 	if c.SafePruneMaxDeletePercent < 0 || c.SafePruneMaxDeletePercent > 100 {
-		return fmt.Errorf("SAFE_PRUNE_MAX_DELETE_PERCENT must be between 0 and 100 (was %d)", c.SafePruneMaxDeletePercent)
+		return apperrors.NewConfigError("safe-prune-max-delete-percent", fmt.Errorf("SAFE_PRUNE_MAX_DELETE_PERCENT must be between 0 and 100 (was %d)", c.SafePruneMaxDeletePercent))
 	}
 	if c.SafePruneMaxDeleteCount < 0 {
-		return fmt.Errorf("SAFE_PRUNE_MAX_DELETE_COUNT must be non-negative (was %d)", c.SafePruneMaxDeleteCount)
+		return apperrors.NewConfigError("safe-prune-max-delete-count", fmt.Errorf("SAFE_PRUNE_MAX_DELETE_COUNT must be non-negative (was %d)", c.SafePruneMaxDeleteCount))
 	}
 	if c.SafePruneMinTotalForPercent < 0 {
-		return fmt.Errorf("SAFE_PRUNE_MIN_TOTAL_FOR_PERCENT must be non-negative (was %d)", c.SafePruneMinTotalForPercent)
+		return apperrors.NewConfigError("safe-prune-min-total-for-percent", fmt.Errorf("SAFE_PRUNE_MIN_TOTAL_FOR_PERCENT must be non-negative (was %d)", c.SafePruneMinTotalForPercent))
 	}
 	if c.LogRetentionDays < 0 {
-		return fmt.Errorf("LOG_RETENTION_DAYS must be non-negative (was %d)", c.LogRetentionDays)
+		return apperrors.NewConfigError("log-retention-days", fmt.Errorf("LOG_RETENTION_DAYS must be non-negative (was %d)", c.LogRetentionDays))
 	}
 	return nil
 }
@@ -268,34 +270,34 @@ func (c *Config) ValidateThresholds() error {
 // remote mode (--remote), as remote targets do not use local file ownership.
 func (c *Config) ValidateOwnerGroup() error {
 	if c.LocalOwner == "" {
-		return fmt.Errorf("LOCAL_OWNER is mandatory: set it in your .conf file to the non-root user that should own backup files (e.g. LOCAL_OWNER=myuser)")
+		return apperrors.NewConfigError("local-owner", fmt.Errorf("LOCAL_OWNER is mandatory: set it in your .conf file to the non-root user that should own backup files (e.g. LOCAL_OWNER=myuser)"))
 	}
 	if c.LocalGroup == "" {
-		return fmt.Errorf("LOCAL_GROUP is mandatory: set it in your .conf file to the group that should own backup files (e.g. LOCAL_GROUP=users)")
+		return apperrors.NewConfigError("local-group", fmt.Errorf("LOCAL_GROUP is mandatory: set it in your .conf file to the group that should own backup files (e.g. LOCAL_GROUP=users)"))
 	}
 	if !ownerPattern.MatchString(c.LocalOwner) {
-		return fmt.Errorf("LOCAL_OWNER has invalid value '%s'", c.LocalOwner)
+		return apperrors.NewConfigError("local-owner", fmt.Errorf("LOCAL_OWNER has invalid value '%s'", c.LocalOwner), "value", c.LocalOwner)
 	}
 	if !ownerPattern.MatchString(c.LocalGroup) {
-		return fmt.Errorf("LOCAL_GROUP has invalid value '%s'", c.LocalGroup)
+		return apperrors.NewConfigError("local-group", fmt.Errorf("LOCAL_GROUP has invalid value '%s'", c.LocalGroup), "value", c.LocalGroup)
 	}
 	// Reject root user/group for security: the backup script runs as root but
 	// repository files must never be owned by root to limit blast-radius of
 	// any future vulnerability in the backup data path.
 	if strings.EqualFold(c.LocalOwner, "root") {
-		return fmt.Errorf("LOCAL_OWNER must not be 'root' for security reasons: backup files should be owned by a non-root user")
+		return apperrors.NewConfigError("local-owner", fmt.Errorf("LOCAL_OWNER must not be 'root' for security reasons: backup files should be owned by a non-root user"))
 	}
 	if strings.EqualFold(c.LocalGroup, "root") {
-		return fmt.Errorf("LOCAL_GROUP must not be 'root' for security reasons: backup files should be owned by a non-root group")
+		return apperrors.NewConfigError("local-group", fmt.Errorf("LOCAL_GROUP must not be 'root' for security reasons: backup files should be owned by a non-root group"))
 	}
 
 	// Verify the specified user actually exists on the system.
 	if _, err := user.Lookup(c.LocalOwner); err != nil {
-		return fmt.Errorf("LOCAL_OWNER '%s' does not exist on this system: %w", c.LocalOwner, err)
+		return apperrors.NewConfigError("local-owner", fmt.Errorf("LOCAL_OWNER '%s' does not exist on this system: %w", c.LocalOwner, err), "value", c.LocalOwner)
 	}
 	// Verify the specified group actually exists on the system.
 	if _, err := user.LookupGroup(c.LocalGroup); err != nil {
-		return fmt.Errorf("LOCAL_GROUP '%s' does not exist on this system: %w", c.LocalGroup, err)
+		return apperrors.NewConfigError("local-group", fmt.Errorf("LOCAL_GROUP '%s' does not exist on this system: %w", c.LocalGroup, err), "value", c.LocalGroup)
 	}
 
 	return nil
@@ -305,7 +307,7 @@ func (c *Config) ValidateOwnerGroup() error {
 func (c *Config) ValidateThreads() error {
 	t := c.Threads
 	if t <= 0 || t > MaxThreads || (t&(t-1)) != 0 {
-		return fmt.Errorf("THREADS must be a power of 2 and <= %d (was %d)", MaxThreads, t)
+		return apperrors.NewConfigError("threads", fmt.Errorf("THREADS must be a power of 2 and <= %d (was %d)", MaxThreads, t))
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,10 +1,13 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	apperrors "github.com/phillipmcmahon/synology-duplicacy-backup/internal/errors"
 )
 
 // helper to write a temp config file and return its path.
@@ -254,6 +257,11 @@ func TestParseFile_NonexistentFile(t *testing.T) {
 	_, err := ParseFile("/nonexistent/config.conf", "local")
 	if err == nil {
 		t.Fatal("expected error for nonexistent file")
+	}
+
+	var configErr *apperrors.ConfigError
+	if !errors.As(err, &configErr) {
+		t.Fatalf("expected ConfigError, got %T", err)
 	}
 }
 

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	apperrors "github.com/phillipmcmahon/synology-duplicacy-backup/internal/errors"
 )
 
 // Lock represents a directory-based process lock.
@@ -32,7 +34,7 @@ func New(lockParent, label string) *Lock {
 func (l *Lock) Acquire() error {
 	// Ensure parent directory exists
 	if err := os.MkdirAll(filepath.Dir(l.Path), 0755); err != nil {
-		return fmt.Errorf("failed to create lock parent directory: %w", err)
+		return apperrors.NewLockError("create-parent", fmt.Errorf("failed to create lock parent directory: %w", err), "path", filepath.Dir(l.Path))
 	}
 
 	// Try to create the lock directory atomically
@@ -44,7 +46,7 @@ func (l *Lock) Acquire() error {
 	existingPID, err := l.readPID()
 	if err == nil && existingPID > 0 {
 		if processExists(existingPID) {
-			return fmt.Errorf("another backup is already running (PID: %d)", existingPID)
+			return apperrors.NewLockError("held", fmt.Errorf("another backup is already running (PID: %d)", existingPID), "pid", strconv.Itoa(existingPID))
 		}
 	}
 
@@ -52,7 +54,7 @@ func (l *Lock) Acquire() error {
 	os.RemoveAll(l.Path)
 
 	if err := os.Mkdir(l.Path, 0755); err != nil {
-		return fmt.Errorf("failed to acquire lock after removing stale lock")
+		return apperrors.NewLockError("stale-retry", fmt.Errorf("failed to acquire lock after removing stale lock"), "path", l.Path)
 	}
 
 	return l.writePID()

--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -1,12 +1,15 @@
 package lock
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
 	"testing"
+
+	apperrors "github.com/phillipmcmahon/synology-duplicacy-backup/internal/errors"
 )
 
 func requireLinuxProc(t *testing.T) {
@@ -158,6 +161,28 @@ func TestAcquire_StaleLockInvalidPID(t *testing.T) {
 		t.Fatalf("Acquire (invalid PID) failed: %v", err)
 	}
 	defer lk.Release()
+}
+
+func TestAcquire_CreateParentFailureReturnsLockError(t *testing.T) {
+	dir := t.TempDir()
+	fileParent := filepath.Join(dir, "not-a-dir")
+	if err := os.WriteFile(fileParent, []byte("x"), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	lk := New(filepath.Join(fileParent, "child"), "test-parent-failure")
+	err := lk.Acquire()
+	if err == nil {
+		t.Fatal("expected error when lock parent cannot be created")
+	}
+
+	var lockErr *apperrors.LockError
+	if !errors.As(err, &lockErr) {
+		t.Fatalf("expected LockError, got %T", err)
+	}
+	if lockErr.Phase != "create-parent" {
+		t.Fatalf("LockError phase = %q, want create-parent", lockErr.Phase)
+	}
 }
 
 // ─── Release tests ──────────────────────────────────────────────────────────

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+
+	apperrors "github.com/phillipmcmahon/synology-duplicacy-backup/internal/errors"
 )
 
 // MinStorjS3IDLen is the minimum length for STORJ_S3_ID.
@@ -42,21 +44,21 @@ func ValidateFileAccess(path string) error {
 	info, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("secrets file not found: %s", path)
+			return apperrors.NewSecretsError("stat", fmt.Errorf("secrets file not found: %s", path), "path", path)
 		}
-		return fmt.Errorf("cannot stat secrets file: %w", err)
+		return apperrors.NewSecretsError("stat", fmt.Errorf("cannot stat secrets file: %w", err), "path", path)
 	}
 
 	// Check permissions (600)
 	perm := info.Mode().Perm()
 	if perm != 0600 {
-		return fmt.Errorf("secrets file permissions are %04o, expected 0600: %s", perm, path)
+		return apperrors.NewSecretsError("permissions", fmt.Errorf("secrets file permissions are %04o, expected 0600: %s", perm, path), "path", path)
 	}
 
 	// Check ownership (root:root)
 	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
 		if stat.Uid != 0 || stat.Gid != 0 {
-			return fmt.Errorf("secrets file ownership is %d:%d, expected 0:0 (root:root): %s", stat.Uid, stat.Gid, path)
+			return apperrors.NewSecretsError("ownership", fmt.Errorf("secrets file ownership is %d:%d, expected 0:0 (root:root): %s", stat.Uid, stat.Gid, path), "path", path)
 		}
 	}
 	return nil
@@ -81,7 +83,7 @@ func ParseSecrets(r io.Reader, source string) (*Secrets, error) {
 		}
 
 		if !strings.Contains(line, "=") {
-			return nil, fmt.Errorf("secrets file has invalid line at %d: %s", lineno, line)
+			return nil, apperrors.NewSecretsError("parse", fmt.Errorf("secrets file has invalid line at %d: %s", lineno, line), "source", source)
 		}
 
 		parts := strings.SplitN(line, "=", 2)
@@ -89,11 +91,11 @@ func ParseSecrets(r io.Reader, source string) (*Secrets, error) {
 		value := strings.TrimSpace(parts[1])
 
 		if key == "" {
-			return nil, fmt.Errorf("secrets file has malformed key=value pair with missing key at line %d", lineno)
+			return nil, apperrors.NewSecretsError("parse", fmt.Errorf("secrets file has malformed key=value pair with missing key at line %d", lineno), "source", source)
 		}
 
 		if !allowedSecretKeys[key] {
-			return nil, fmt.Errorf("unexpected key '%s' in secrets file at line %d", key, lineno)
+			return nil, apperrors.NewSecretsError("parse", fmt.Errorf("unexpected key '%s' in secrets file at line %d", key, lineno), "source", source)
 		}
 
 		// Strip surrounding quotes
@@ -105,7 +107,7 @@ func ParseSecrets(r io.Reader, source string) (*Secrets, error) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("error reading secrets file: %w", err)
+		return nil, apperrors.NewSecretsError("read", fmt.Errorf("error reading secrets file: %w", err), "source", source)
 	}
 
 	s := &Secrets{
@@ -114,10 +116,10 @@ func ParseSecrets(r io.Reader, source string) (*Secrets, error) {
 	}
 
 	if s.StorjS3ID == "" {
-		return nil, fmt.Errorf("required secret 'STORJ_S3_ID' is missing after loading %s", source)
+		return nil, apperrors.NewSecretsError("required", fmt.Errorf("required secret 'STORJ_S3_ID' is missing after loading %s", source), "source", source)
 	}
 	if s.StorjS3Secret == "" {
-		return nil, fmt.Errorf("required secret 'STORJ_S3_SECRET' is missing after loading %s", source)
+		return nil, apperrors.NewSecretsError("required", fmt.Errorf("required secret 'STORJ_S3_SECRET' is missing after loading %s", source), "source", source)
 	}
 
 	return s, nil
@@ -133,7 +135,7 @@ func LoadSecretsFile(path string) (*Secrets, error) {
 
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("secrets file is not readable: %s", path)
+		return nil, apperrors.NewSecretsError("open", fmt.Errorf("secrets file is not readable: %s", path), "path", path)
 	}
 	defer f.Close()
 
@@ -143,10 +145,10 @@ func LoadSecretsFile(path string) (*Secrets, error) {
 // Validate checks minimum length requirements for secrets.
 func (s *Secrets) Validate() error {
 	if len(s.StorjS3ID) < MinStorjS3IDLen {
-		return fmt.Errorf("STORJ_S3_ID must be at least %d characters (was %d)", MinStorjS3IDLen, len(s.StorjS3ID))
+		return apperrors.NewSecretsError("validate", fmt.Errorf("STORJ_S3_ID must be at least %d characters (was %d)", MinStorjS3IDLen, len(s.StorjS3ID)))
 	}
 	if len(s.StorjS3Secret) < MinStorjS3SecretLen {
-		return fmt.Errorf("STORJ_S3_SECRET must be at least %d characters (was %d)", MinStorjS3SecretLen, len(s.StorjS3Secret))
+		return apperrors.NewSecretsError("validate", fmt.Errorf("STORJ_S3_SECRET must be at least %d characters (was %d)", MinStorjS3SecretLen, len(s.StorjS3Secret)))
 	}
 	return nil
 }

--- a/internal/secrets/secrets_test.go
+++ b/internal/secrets/secrets_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	apperrors "github.com/phillipmcmahon/synology-duplicacy-backup/internal/errors"
 )
 
 // writeTempSecrets creates a temp secrets file with given content and perms.
@@ -87,6 +89,11 @@ func TestLoadSecretsFile_MissingFile(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not found") {
 		t.Errorf("error should mention 'not found', got: %v", err)
+	}
+
+	var secretsErr *apperrors.SecretsError
+	if !errors.As(err, &secretsErr) {
+		t.Fatalf("expected SecretsError, got %T", err)
 	}
 }
 

--- a/internal/workflow/cleanup.go
+++ b/internal/workflow/cleanup.go
@@ -1,0 +1,79 @@
+package workflow
+
+import (
+	"os"
+
+	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/btrfs"
+)
+
+func (e *Executor) cleanup() {
+	if e.cleanedUp {
+		return
+	}
+	e.cleanedUp = true
+
+	e.log.Info("%s", statusLinef("Starting cleanup."))
+	e.cleanupSnapshot()
+	e.cleanupWorkRoot()
+	e.releaseLock()
+
+	e.view.PrintCompletion(e.exitCode)
+	e.log.Close()
+}
+
+func (e *Executor) cleanupSnapshot() {
+	if !e.plan.NeedsSnapshot {
+		return
+	}
+
+	if _, err := os.Stat(e.plan.SnapshotTarget); err == nil {
+		e.log.Info("%s", statusLinef("Deleting snapshot subvolume: %s.", e.plan.SnapshotTarget))
+		if e.plan.DryRun {
+			e.log.DryRun("%s", e.plan.SnapshotDeleteCommand)
+		} else if delErr := btrfs.DeleteSnapshot(e.runner, e.plan.SnapshotTarget, false); delErr != nil {
+			e.log.Warn("%s", statusLinef("Failed to delete subvolume %s: %v.", e.plan.SnapshotTarget, delErr))
+		}
+	}
+
+	if _, err := os.Stat(e.plan.SnapshotTarget); err == nil {
+		e.log.Info("%s", statusLinef("Removing snapshot directory: %s.", e.plan.SnapshotTarget))
+		if e.plan.DryRun {
+			e.log.DryRun("rm -rf %s", e.plan.SnapshotTarget)
+		} else if rmErr := os.RemoveAll(e.plan.SnapshotTarget); rmErr != nil {
+			e.log.Warn("%s", statusLinef("Failed to remove snapshot directory %s: %v.", e.plan.SnapshotTarget, rmErr))
+		}
+	}
+}
+
+func (e *Executor) cleanupWorkRoot() {
+	workRoot := e.plan.WorkRoot
+	if e.dup != nil {
+		workRoot = e.dup.WorkRoot
+	}
+	if _, err := os.Stat(workRoot); err != nil {
+		return
+	}
+
+	e.log.Info("%s", statusLinef("Removing duplicacy work directory: %s.", workRoot))
+	if e.plan.DryRun {
+		e.log.DryRun("%s", e.plan.WorkDirRemoveCommand)
+		return
+	}
+
+	if e.dup != nil {
+		if err := e.dup.Cleanup(); err != nil {
+			e.log.Warn("%s", statusLinef("Failed to remove work directory: %v.", err))
+		}
+		return
+	}
+
+	if err := os.RemoveAll(workRoot); err != nil {
+		e.log.Warn("%s", statusLinef("Failed to remove work directory %s: %v.", workRoot, err))
+	}
+}
+
+func (e *Executor) releaseLock() {
+	if e.lockAcquired {
+		e.lock.Release()
+	}
+}

--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -45,7 +45,7 @@ func (e *Executor) Run() int {
 	defer e.cleanup()
 
 	if e.plan.DefaultNotice != "" {
-		e.log.Info("%s", e.plan.DefaultNotice)
+		e.log.Info("%s", statusLinef("%s", e.plan.DefaultNotice))
 	}
 	e.log.CleanupOldLogs(e.plan.LogRetentionDays, e.plan.DryRun)
 
@@ -62,7 +62,7 @@ func (e *Executor) Run() int {
 		return e.exitCode
 	}
 
-	e.log.Info("All operations completed.")
+	e.log.Info("%s", statusLinef("All operations completed."))
 	return 0
 }
 
@@ -71,7 +71,7 @@ func (e *Executor) installSignalHandler() {
 	e.rt.SignalNotify(sigChan, SignalSet()...)
 	go func() {
 		sig := <-sigChan
-		e.log.Warn("Received signal: %v — initiating cleanup.", sig)
+		e.log.Warn("%s", statusLinef("Received signal: %v — initiating cleanup.", sig))
 		e.exitCode = 1
 		e.cleanup()
 		os.Exit(1)
@@ -79,12 +79,12 @@ func (e *Executor) installSignalHandler() {
 }
 
 func (e *Executor) acquireLock() error {
-	e.log.Info("Acquiring lock for label %q.", e.plan.BackupLabel)
+	e.log.Info("%s", statusLinef("Acquiring lock for label %q.", e.plan.BackupLabel))
 	if err := e.lock.Acquire(); err != nil {
-		return fmt.Errorf("Lock acquisition failed: %w", err)
+		return err
 	}
 	e.lockAcquired = true
-	e.log.Info("Lock acquired: %s.", e.lock.Path)
+	e.log.Info("%s", statusLinef("Lock acquired: %s.", e.lock.Path))
 	return nil
 }
 
@@ -114,13 +114,13 @@ func (e *Executor) execute() error {
 
 func (e *Executor) prepareDuplicacySetup() error {
 	if e.plan.NeedsSnapshot {
-		e.log.Info("Creating btrfs snapshot: %s → %s.", e.plan.SnapshotSource, e.plan.SnapshotTarget)
+		e.log.Info("%s", statusLinef("Creating btrfs snapshot: %s → %s.", e.plan.SnapshotSource, e.plan.SnapshotTarget))
 		if e.plan.DryRun {
 			e.log.DryRun("btrfs subvolume snapshot -r %s %s", e.plan.SnapshotSource, e.plan.SnapshotTarget)
 		} else if err := btrfs.CreateSnapshot(e.runner, e.plan.SnapshotSource, e.plan.SnapshotTarget, false); err != nil {
 			return err
 		} else {
-			e.log.Info("Snapshot created successfully.")
+			e.log.Info("%s", statusLinef("Snapshot created successfully."))
 		}
 	}
 
@@ -140,14 +140,14 @@ func (e *Executor) prepareDuplicacySetup() error {
 	}
 
 	if e.plan.DoBackup && e.plan.Filter != "" {
-		e.log.Info("Creating filter definitions.")
+		e.log.Info("%s", statusLinef("Creating filter definitions."))
 		if err := dup.WriteFilters(e.plan.Filter); err != nil {
 			return err
 		}
 		if e.plan.DryRun {
-			e.log.DryRun("Write filters to %s", dup.FilterFile)
+			e.log.DryRun("write filters to %s", dup.FilterFile)
 		} else {
-			e.log.Info("Active filters:")
+			e.log.Info("%s", statusLinef("Active filters:"))
 		}
 		for _, line := range e.plan.FilterLines {
 			e.log.Info("  %s", line)
@@ -162,16 +162,16 @@ func (e *Executor) prepareDuplicacySetup() error {
 		e.log.DryRun("find %s -type f -exec chmod 660 {} +", dup.DuplicacyRoot)
 	}
 
-	e.log.Info("Changing to directory: %s.", dup.DuplicacyRoot)
+	e.log.Info("%s", statusLinef("Changing to directory: %s.", dup.DuplicacyRoot))
 	e.dup = dup
 	return nil
 }
 
 func (e *Executor) runBackupPhase() error {
-	e.log.Info("Starting backup phase.")
+	e.log.Info("%s", statusLinef("Starting backup phase."))
 	if e.plan.DryRun {
 		e.log.DryRun("duplicacy backup -stats -threads %d", e.plan.Threads)
-		e.log.Info("Backup phase completed (dry-run).")
+		e.log.Info("%s", statusLinef("Backup phase completed (dry-run)."))
 		return nil
 	}
 
@@ -180,12 +180,12 @@ func (e *Executor) runBackupPhase() error {
 	if err != nil {
 		return err
 	}
-	e.log.Info("Backup phase completed successfully.")
+	e.log.Info("%s", statusLinef("Backup phase completed successfully."))
 	return nil
 }
 
 func (e *Executor) runPrunePhase() error {
-	e.log.Info("Starting prune phase.")
+	e.log.Info("%s", statusLinef("Starting prune phase."))
 
 	if e.plan.DryRun {
 		e.log.DryRun("duplicacy list -files")
@@ -193,7 +193,7 @@ func (e *Executor) runPrunePhase() error {
 		if err := e.dup.ValidateRepo(); err != nil {
 			return err
 		}
-		e.log.Info("Duplicacy repository validated.")
+		e.log.Info("%s", statusLinef("Duplicacy repository validated."))
 	}
 
 	if e.plan.DryRun {
@@ -221,7 +221,7 @@ func (e *Executor) runPrunePhase() error {
 
 	if preview.RevisionCountFailed {
 		if e.plan.Request.ForcePrune {
-			e.log.Warn("Revision count failed; proceeding because --force-prune was supplied (percentage threshold not enforced).")
+			e.log.Warn("%s", statusLinef("Revision count failed; proceeding because --force-prune was supplied (percentage threshold not enforced)."))
 		} else {
 			return NewMessageError("Revision count is required for safe prune but failed; use --force-prune to override.")
 		}
@@ -231,22 +231,22 @@ func (e *Executor) runPrunePhase() error {
 
 	blocked := false
 	if preview.DeleteCount > e.plan.SafePruneMaxDeleteCount {
-		e.log.Error("Safe prune preview exceeds delete count threshold: %d > %d.", preview.DeleteCount, e.plan.SafePruneMaxDeleteCount)
+		e.log.Error("%s", statusLinef("Safe prune preview exceeds delete count threshold: %d > %d.", preview.DeleteCount, e.plan.SafePruneMaxDeleteCount))
 		blocked = true
 	}
 	if preview.ExceedsPercent(e.plan.SafePruneMaxDeletePercent) {
-		e.log.Error("Safe prune preview exceeds delete percentage threshold (%d of %d revisions > %d%%).", preview.DeleteCount, preview.TotalRevisions, e.plan.SafePruneMaxDeletePercent)
+		e.log.Error("%s", statusLinef("Safe prune preview exceeds delete percentage threshold (%d of %d revisions > %d%%).", preview.DeleteCount, preview.TotalRevisions, e.plan.SafePruneMaxDeletePercent))
 		blocked = true
 	}
 	if blocked {
 		if e.plan.ForcePrune {
-			e.log.Warn("Proceeding despite safe prune threshold breach because --force-prune was supplied.")
+			e.log.Warn("%s", statusLinef("Proceeding despite safe prune threshold breach because --force-prune was supplied."))
 		} else {
 			return NewMessageError("Refusing to continue because safe prune thresholds were exceeded.")
 		}
 	}
 
-	e.log.Info("Starting policy prune.")
+	e.log.Info("%s", statusLinef("Starting policy prune."))
 	if e.plan.DryRun {
 		e.log.DryRun("duplicacy prune %s", e.plan.PruneArgsDisplay)
 	} else {
@@ -256,10 +256,10 @@ func (e *Executor) runPrunePhase() error {
 			return err
 		}
 	}
-	e.log.Info("Policy prune completed.")
+	e.log.Info("%s", statusLinef("Policy prune completed."))
 
 	if e.plan.DeepPruneMode {
-		e.log.Warn("Starting deep prune maintenance step: duplicacy prune -exhaustive -exclusive.")
+		e.log.Warn("%s", statusLinef("Starting deep prune maintenance step: duplicacy prune -exhaustive -exclusive."))
 		if e.plan.DryRun {
 			e.log.DryRun("duplicacy prune -exhaustive -exclusive")
 		} else {
@@ -269,15 +269,15 @@ func (e *Executor) runPrunePhase() error {
 				return err
 			}
 		}
-		e.log.Info("Deep prune completed.")
+		e.log.Info("%s", statusLinef("Deep prune completed."))
 	}
 
-	e.log.Info("Prune phase completed successfully.")
+	e.log.Info("%s", statusLinef("Prune phase completed successfully."))
 	return nil
 }
 
 func (e *Executor) runFixPermsPhase() error {
-	e.log.Info("Starting permission normalisation on %s.", e.plan.BackupTarget)
+	e.log.Info("%s", statusLinef("Starting permission normalisation on %s.", e.plan.BackupTarget))
 	e.log.PrintLine("Fix Perms Path", e.plan.BackupTarget)
 	e.log.PrintLine("Fix Perms Owner", e.plan.LocalOwner)
 	e.log.PrintLine("Fix Perms Group", e.plan.LocalGroup)
@@ -287,14 +287,14 @@ func (e *Executor) runFixPermsPhase() error {
 		e.log.DryRun("chown -R %s %s", ownerGroup, e.plan.BackupTarget)
 		e.log.DryRun("find %s -type d -exec chmod 770 {} +", e.plan.BackupTarget)
 		e.log.DryRun("find %s -type f -exec chmod 660 {} +", e.plan.BackupTarget)
-		e.log.Info("Permission normalisation completed (dry-run).")
+		e.log.Info("%s", statusLinef("Permission normalisation completed (dry-run)."))
 		return nil
 	}
 
 	if err := permissions.Fix(e.runner, e.plan.BackupTarget, e.plan.LocalOwner, e.plan.LocalGroup, false); err != nil {
 		return err
 	}
-	e.log.Info("Permission normalisation completed successfully.")
+	e.log.Info("%s", statusLinef("Permission normalisation completed successfully."))
 	return nil
 }
 
@@ -304,41 +304,41 @@ func (e *Executor) cleanup() {
 	}
 	e.cleanedUp = true
 
-	e.log.Info("Starting cleanup.")
+	e.log.Info("%s", statusLinef("Starting cleanup."))
 
 	if e.plan.NeedsSnapshot {
 		if _, err := os.Stat(e.plan.SnapshotTarget); err == nil {
-			e.log.Info("Deleting snapshot subvolume: %s.", e.plan.SnapshotTarget)
+			e.log.Info("%s", statusLinef("Deleting snapshot subvolume: %s.", e.plan.SnapshotTarget))
 			if e.plan.DryRun {
 				e.log.DryRun("btrfs subvolume delete %s", e.plan.SnapshotTarget)
 			} else if delErr := btrfs.DeleteSnapshot(e.runner, e.plan.SnapshotTarget, false); delErr != nil {
-				e.log.Warn("Failed to delete subvolume %s: %v.", e.plan.SnapshotTarget, delErr)
+				e.log.Warn("%s", statusLinef("Failed to delete subvolume %s: %v.", e.plan.SnapshotTarget, delErr))
 			}
 		}
 
 		if _, err := os.Stat(e.plan.SnapshotTarget); err == nil {
-			e.log.Info("Removing snapshot directory: %s.", e.plan.SnapshotTarget)
+			e.log.Info("%s", statusLinef("Removing snapshot directory: %s.", e.plan.SnapshotTarget))
 			if e.plan.DryRun {
 				e.log.DryRun("rm -rf %s", e.plan.SnapshotTarget)
 			} else if rmErr := os.RemoveAll(e.plan.SnapshotTarget); rmErr != nil {
-				e.log.Warn("Failed to remove snapshot directory %s.", e.plan.SnapshotTarget)
+				e.log.Warn("%s", statusLinef("Failed to remove snapshot directory %s: %v.", e.plan.SnapshotTarget, rmErr))
 			}
 		}
 	}
 
 	if e.dup != nil {
-		e.log.Info("Removing duplicacy work directory: %s.", e.dup.WorkRoot)
+		e.log.Info("%s", statusLinef("Removing duplicacy work directory: %s.", e.dup.WorkRoot))
 		if e.plan.DryRun {
 			e.log.DryRun("rm -rf %s", e.dup.WorkRoot)
 		} else if err := e.dup.Cleanup(); err != nil {
-			e.log.Warn("Failed to remove work directory: %v.", err)
+			e.log.Warn("%s", statusLinef("Failed to remove work directory: %v.", err))
 		}
 	} else if _, err := os.Stat(e.plan.WorkRoot); err == nil {
-		e.log.Info("Removing duplicacy work directory: %s.", e.plan.WorkRoot)
+		e.log.Info("%s", statusLinef("Removing duplicacy work directory: %s.", e.plan.WorkRoot))
 		if e.plan.DryRun {
 			e.log.DryRun("rm -rf %s", e.plan.WorkRoot)
 		} else if rmErr := os.RemoveAll(e.plan.WorkRoot); rmErr != nil {
-			e.log.Warn("Failed to remove work directory %s: %v.", e.plan.WorkRoot, rmErr)
+			e.log.Warn("%s", statusLinef("Failed to remove work directory %s: %v.", e.plan.WorkRoot, rmErr))
 		}
 	}
 

--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -1,16 +1,13 @@
 package workflow
 
 import (
-	"fmt"
 	"os"
-	"strings"
 
 	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/btrfs"
 	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/duplicacy"
 	execpkg "github.com/phillipmcmahon/synology-duplicacy-backup/internal/exec"
 	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/lock"
 	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/logger"
-	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/permissions"
 )
 
 type Executor struct {
@@ -116,7 +113,7 @@ func (e *Executor) prepareDuplicacySetup() error {
 	if e.plan.NeedsSnapshot {
 		e.log.Info("%s", statusLinef("Creating btrfs snapshot: %s → %s.", e.plan.SnapshotSource, e.plan.SnapshotTarget))
 		if e.plan.DryRun {
-			e.log.DryRun("btrfs subvolume snapshot -r %s %s", e.plan.SnapshotSource, e.plan.SnapshotTarget)
+			e.log.DryRun("%s", e.plan.SnapshotCreateCommand)
 		} else if err := btrfs.CreateSnapshot(e.runner, e.plan.SnapshotSource, e.plan.SnapshotTarget, false); err != nil {
 			return err
 		} else {
@@ -129,14 +126,14 @@ func (e *Executor) prepareDuplicacySetup() error {
 		return err
 	}
 	if e.plan.DryRun {
-		e.log.DryRun("mkdir -p %s", dup.DuplicacyDir)
+		e.log.DryRun("%s", e.plan.WorkDirCreateCommand)
 	}
 
 	if err := dup.WritePreferences(e.plan.Secrets); err != nil {
 		return err
 	}
 	if e.plan.DryRun {
-		e.log.DryRun("write JSON preferences to %s", dup.PrefsFile)
+		e.log.DryRun("%s", e.plan.PreferencesWriteCommand)
 	}
 
 	if e.plan.DoBackup && e.plan.Filter != "" {
@@ -145,7 +142,7 @@ func (e *Executor) prepareDuplicacySetup() error {
 			return err
 		}
 		if e.plan.DryRun {
-			e.log.DryRun("write filters to %s", dup.FilterFile)
+			e.log.DryRun("%s", e.plan.FiltersWriteCommand)
 		} else {
 			e.log.Info("%s", statusLinef("Active filters:"))
 		}
@@ -158,8 +155,8 @@ func (e *Executor) prepareDuplicacySetup() error {
 		return err
 	}
 	if e.plan.DryRun {
-		e.log.DryRun("find %s -type d -exec chmod 770 {} +", dup.DuplicacyRoot)
-		e.log.DryRun("find %s -type f -exec chmod 660 {} +", dup.DuplicacyRoot)
+		e.log.DryRun("%s", e.plan.WorkDirDirPermsCommand)
+		e.log.DryRun("%s", e.plan.WorkDirFilePermsCommand)
 	}
 
 	e.log.Info("%s", statusLinef("Changing to directory: %s.", dup.DuplicacyRoot))
@@ -170,7 +167,7 @@ func (e *Executor) prepareDuplicacySetup() error {
 func (e *Executor) runBackupPhase() error {
 	e.log.Info("%s", statusLinef("Starting backup phase."))
 	if e.plan.DryRun {
-		e.log.DryRun("duplicacy backup -stats -threads %d", e.plan.Threads)
+		e.log.DryRun("%s", e.plan.BackupCommand)
 		e.log.Info("%s", statusLinef("Backup phase completed (dry-run)."))
 		return nil
 	}
@@ -182,172 +179,6 @@ func (e *Executor) runBackupPhase() error {
 	}
 	e.log.Info("%s", statusLinef("Backup phase completed successfully."))
 	return nil
-}
-
-func (e *Executor) runPrunePhase() error {
-	e.log.Info("%s", statusLinef("Starting prune phase."))
-
-	if e.plan.DryRun {
-		e.log.DryRun("duplicacy list -files")
-	} else {
-		if err := e.dup.ValidateRepo(); err != nil {
-			return err
-		}
-		e.log.Info("%s", statusLinef("Duplicacy repository validated."))
-	}
-
-	if e.plan.DryRun {
-		e.log.DryRun("duplicacy prune %s -dry-run", e.plan.PruneArgsDisplay)
-	}
-	preview, err := e.dup.SafePrunePreview(e.plan.PruneArgs, e.plan.SafePruneMinTotalForPercent)
-	if err != nil {
-		return err
-	}
-
-	if preview.Output != "" {
-		for _, line := range strings.Split(preview.Output, "\n") {
-			if line != "" {
-				e.log.Info("[SAFE-PRUNE-PREVIEW] %s", line)
-			}
-		}
-	}
-	if preview.RevisionOutput != "" {
-		for _, line := range strings.Split(preview.RevisionOutput, "\n") {
-			if line != "" {
-				e.log.Info("[REVISION-LIST] %s", line)
-			}
-		}
-	}
-
-	if preview.RevisionCountFailed {
-		if e.plan.Request.ForcePrune {
-			e.log.Warn("%s", statusLinef("Revision count failed; proceeding because --force-prune was supplied (percentage threshold not enforced)."))
-		} else {
-			return NewMessageError("Revision count is required for safe prune but failed; use --force-prune to override.")
-		}
-	}
-
-	e.view.PrintPrunePreview(preview, e.plan.SafePruneMinTotalForPercent)
-
-	blocked := false
-	if preview.DeleteCount > e.plan.SafePruneMaxDeleteCount {
-		e.log.Error("%s", statusLinef("Safe prune preview exceeds delete count threshold: %d > %d.", preview.DeleteCount, e.plan.SafePruneMaxDeleteCount))
-		blocked = true
-	}
-	if preview.ExceedsPercent(e.plan.SafePruneMaxDeletePercent) {
-		e.log.Error("%s", statusLinef("Safe prune preview exceeds delete percentage threshold (%d of %d revisions > %d%%).", preview.DeleteCount, preview.TotalRevisions, e.plan.SafePruneMaxDeletePercent))
-		blocked = true
-	}
-	if blocked {
-		if e.plan.ForcePrune {
-			e.log.Warn("%s", statusLinef("Proceeding despite safe prune threshold breach because --force-prune was supplied."))
-		} else {
-			return NewMessageError("Refusing to continue because safe prune thresholds were exceeded.")
-		}
-	}
-
-	e.log.Info("%s", statusLinef("Starting policy prune."))
-	if e.plan.DryRun {
-		e.log.DryRun("duplicacy prune %s", e.plan.PruneArgsDisplay)
-	} else {
-		stdout, stderr, err := e.dup.RunPrune(e.plan.PruneArgs)
-		e.view.PrintCommandOutput(stdout, stderr)
-		if err != nil {
-			return err
-		}
-	}
-	e.log.Info("%s", statusLinef("Policy prune completed."))
-
-	if e.plan.DeepPruneMode {
-		e.log.Warn("%s", statusLinef("Starting deep prune maintenance step: duplicacy prune -exhaustive -exclusive."))
-		if e.plan.DryRun {
-			e.log.DryRun("duplicacy prune -exhaustive -exclusive")
-		} else {
-			stdout, stderr, err := e.dup.RunDeepPrune()
-			e.view.PrintCommandOutput(stdout, stderr)
-			if err != nil {
-				return err
-			}
-		}
-		e.log.Info("%s", statusLinef("Deep prune completed."))
-	}
-
-	e.log.Info("%s", statusLinef("Prune phase completed successfully."))
-	return nil
-}
-
-func (e *Executor) runFixPermsPhase() error {
-	e.log.Info("%s", statusLinef("Starting permission normalisation on %s.", e.plan.BackupTarget))
-	e.log.PrintLine("Fix Perms Path", e.plan.BackupTarget)
-	e.log.PrintLine("Fix Perms Owner", e.plan.LocalOwner)
-	e.log.PrintLine("Fix Perms Group", e.plan.LocalGroup)
-
-	if e.plan.DryRun {
-		ownerGroup := fmt.Sprintf("%s:%s", e.plan.LocalOwner, e.plan.LocalGroup)
-		e.log.DryRun("chown -R %s %s", ownerGroup, e.plan.BackupTarget)
-		e.log.DryRun("find %s -type d -exec chmod 770 {} +", e.plan.BackupTarget)
-		e.log.DryRun("find %s -type f -exec chmod 660 {} +", e.plan.BackupTarget)
-		e.log.Info("%s", statusLinef("Permission normalisation completed (dry-run)."))
-		return nil
-	}
-
-	if err := permissions.Fix(e.runner, e.plan.BackupTarget, e.plan.LocalOwner, e.plan.LocalGroup, false); err != nil {
-		return err
-	}
-	e.log.Info("%s", statusLinef("Permission normalisation completed successfully."))
-	return nil
-}
-
-func (e *Executor) cleanup() {
-	if e.cleanedUp {
-		return
-	}
-	e.cleanedUp = true
-
-	e.log.Info("%s", statusLinef("Starting cleanup."))
-
-	if e.plan.NeedsSnapshot {
-		if _, err := os.Stat(e.plan.SnapshotTarget); err == nil {
-			e.log.Info("%s", statusLinef("Deleting snapshot subvolume: %s.", e.plan.SnapshotTarget))
-			if e.plan.DryRun {
-				e.log.DryRun("btrfs subvolume delete %s", e.plan.SnapshotTarget)
-			} else if delErr := btrfs.DeleteSnapshot(e.runner, e.plan.SnapshotTarget, false); delErr != nil {
-				e.log.Warn("%s", statusLinef("Failed to delete subvolume %s: %v.", e.plan.SnapshotTarget, delErr))
-			}
-		}
-
-		if _, err := os.Stat(e.plan.SnapshotTarget); err == nil {
-			e.log.Info("%s", statusLinef("Removing snapshot directory: %s.", e.plan.SnapshotTarget))
-			if e.plan.DryRun {
-				e.log.DryRun("rm -rf %s", e.plan.SnapshotTarget)
-			} else if rmErr := os.RemoveAll(e.plan.SnapshotTarget); rmErr != nil {
-				e.log.Warn("%s", statusLinef("Failed to remove snapshot directory %s: %v.", e.plan.SnapshotTarget, rmErr))
-			}
-		}
-	}
-
-	if e.dup != nil {
-		e.log.Info("%s", statusLinef("Removing duplicacy work directory: %s.", e.dup.WorkRoot))
-		if e.plan.DryRun {
-			e.log.DryRun("rm -rf %s", e.dup.WorkRoot)
-		} else if err := e.dup.Cleanup(); err != nil {
-			e.log.Warn("%s", statusLinef("Failed to remove work directory: %v.", err))
-		}
-	} else if _, err := os.Stat(e.plan.WorkRoot); err == nil {
-		e.log.Info("%s", statusLinef("Removing duplicacy work directory: %s.", e.plan.WorkRoot))
-		if e.plan.DryRun {
-			e.log.DryRun("rm -rf %s", e.plan.WorkRoot)
-		} else if rmErr := os.RemoveAll(e.plan.WorkRoot); rmErr != nil {
-			e.log.Warn("%s", statusLinef("Failed to remove work directory %s: %v.", e.plan.WorkRoot, rmErr))
-		}
-	}
-
-	if e.lockAcquired {
-		e.lock.Release()
-	}
-
-	e.view.PrintCompletion(e.exitCode)
-	e.log.Close()
 }
 
 func (e *Executor) fail(err error) {

--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -19,6 +19,7 @@ type Executor struct {
 	log    *logger.Logger
 	runner execpkg.Runner
 	plan   *Plan
+	view   *Presenter
 
 	lock         *lock.Lock
 	dup          *duplicacy.Setup
@@ -34,6 +35,7 @@ func NewExecutor(meta Metadata, rt Runtime, log *logger.Logger, runner execpkg.R
 		log:    log,
 		runner: runner,
 		plan:   plan,
+		view:   NewPresenter(meta, rt, log),
 		lock:   rt.NewLock(meta.LockParent, plan.BackupLabel),
 	}
 }
@@ -42,18 +44,18 @@ func (e *Executor) Run() int {
 	e.installSignalHandler()
 	defer e.cleanup()
 
-	if e.plan.Request.DefaultNotice != "" {
-		e.log.Info("%s", e.plan.Request.DefaultNotice)
+	if e.plan.DefaultNotice != "" {
+		e.log.Info("%s", e.plan.DefaultNotice)
 	}
-	e.log.CleanupOldLogs(e.plan.Config.LogRetentionDays, e.plan.Request.DryRun)
+	e.log.CleanupOldLogs(e.plan.LogRetentionDays, e.plan.DryRun)
 
 	if err := e.acquireLock(); err != nil {
 		e.fail(err)
 		return e.exitCode
 	}
 
-	e.printHeader()
-	e.printSummary()
+	e.view.PrintHeader(e.lock.Path)
+	e.view.PrintSummary(e.plan)
 
 	if err := e.execute(); err != nil {
 		e.fail(err)
@@ -86,39 +88,23 @@ func (e *Executor) acquireLock() error {
 	return nil
 }
 
-func (e *Executor) printHeader() {
-	e.log.PrintSeparator()
-	e.log.Info("Backup script started - %s", e.rt.Now().Format("2006-01-02 15:04:05"))
-	e.log.PrintLine("Script", e.meta.ScriptName)
-	e.log.PrintLine("PID", fmt.Sprintf("%d", e.rt.Getpid()))
-	e.log.PrintLine("Lock Path", e.lock.Path)
-	e.log.PrintSeparator()
-}
-
-func (e *Executor) printSummary() {
-	e.log.Info("Configuration Summary:")
-	for _, line := range SummaryLines(e.plan) {
-		e.log.PrintLine(line.Label, line.Value)
-	}
-}
-
 func (e *Executor) execute() error {
-	if e.plan.Request.DoBackup || e.plan.Request.DoPrune {
+	if e.plan.NeedsDuplicacySetup {
 		if err := e.prepareDuplicacySetup(); err != nil {
 			return err
 		}
 	}
-	if e.plan.Request.DoBackup {
+	if e.plan.DoBackup {
 		if err := e.runBackupPhase(); err != nil {
 			return err
 		}
 	}
-	if e.plan.Request.DoPrune {
+	if e.plan.DoPrune {
 		if err := e.runPrunePhase(); err != nil {
 			return err
 		}
 	}
-	if e.plan.Request.FixPerms {
+	if e.plan.FixPerms {
 		if err := e.runFixPermsPhase(); err != nil {
 			return err
 		}
@@ -127,53 +113,51 @@ func (e *Executor) execute() error {
 }
 
 func (e *Executor) prepareDuplicacySetup() error {
-	if e.plan.Request.DoBackup {
+	if e.plan.NeedsSnapshot {
 		e.log.Info("Creating btrfs snapshot: %s → %s.", e.plan.SnapshotSource, e.plan.SnapshotTarget)
-		if e.plan.Request.DryRun {
+		if e.plan.DryRun {
 			e.log.DryRun("btrfs subvolume snapshot -r %s %s", e.plan.SnapshotSource, e.plan.SnapshotTarget)
 		} else if err := btrfs.CreateSnapshot(e.runner, e.plan.SnapshotSource, e.plan.SnapshotTarget, false); err != nil {
-			return fmt.Errorf("Failed to create snapshot: %w.", err)
+			return err
 		} else {
 			e.log.Info("Snapshot created successfully.")
 		}
 	}
 
-	dup := duplicacy.NewSetup(e.plan.WorkRoot, e.plan.RepositoryPath, e.plan.BackupTarget, e.plan.Request.DryRun, e.runner)
+	dup := duplicacy.NewSetup(e.plan.WorkRoot, e.plan.RepositoryPath, e.plan.BackupTarget, e.plan.DryRun, e.runner)
 	if err := dup.CreateDirs(); err != nil {
 		return err
 	}
-	if e.plan.Request.DryRun {
+	if e.plan.DryRun {
 		e.log.DryRun("mkdir -p %s", dup.DuplicacyDir)
 	}
 
 	if err := dup.WritePreferences(e.plan.Secrets); err != nil {
-		return fmt.Errorf("Failed to write preferences: %w", err)
+		return err
 	}
-	if e.plan.Request.DryRun {
+	if e.plan.DryRun {
 		e.log.DryRun("write JSON preferences to %s", dup.PrefsFile)
 	}
 
-	if e.plan.Request.DoBackup && e.plan.Config.Filter != "" {
+	if e.plan.DoBackup && e.plan.Filter != "" {
 		e.log.Info("Creating filter definitions.")
-		if err := dup.WriteFilters(e.plan.Config.Filter); err != nil {
+		if err := dup.WriteFilters(e.plan.Filter); err != nil {
 			return err
 		}
-		if e.plan.Request.DryRun {
+		if e.plan.DryRun {
 			e.log.DryRun("Write filters to %s", dup.FilterFile)
 		} else {
 			e.log.Info("Active filters:")
 		}
-		for _, line := range strings.Split(e.plan.Config.Filter, "\n") {
-			if line != "" {
-				e.log.Info("  %s", line)
-			}
+		for _, line := range e.plan.FilterLines {
+			e.log.Info("  %s", line)
 		}
 	}
 
 	if err := dup.SetPermissions(); err != nil {
 		return err
 	}
-	if e.plan.Request.DryRun {
+	if e.plan.DryRun {
 		e.log.DryRun("find %s -type d -exec chmod 770 {} +", dup.DuplicacyRoot)
 		e.log.DryRun("find %s -type f -exec chmod 660 {} +", dup.DuplicacyRoot)
 	}
@@ -185,16 +169,16 @@ func (e *Executor) prepareDuplicacySetup() error {
 
 func (e *Executor) runBackupPhase() error {
 	e.log.Info("Starting backup phase.")
-	if e.plan.Request.DryRun {
-		e.log.DryRun("duplicacy backup -stats -threads %d", e.plan.Config.Threads)
+	if e.plan.DryRun {
+		e.log.DryRun("duplicacy backup -stats -threads %d", e.plan.Threads)
 		e.log.Info("Backup phase completed (dry-run).")
 		return nil
 	}
 
-	stdout, stderr, err := e.dup.RunBackup(e.plan.Config.Threads)
-	e.printCommandOutput(stdout, stderr)
+	stdout, stderr, err := e.dup.RunBackup(e.plan.Threads)
+	e.view.PrintCommandOutput(stdout, stderr)
 	if err != nil {
-		return fmt.Errorf("Backup failed: %w.", err)
+		return err
 	}
 	e.log.Info("Backup phase completed successfully.")
 	return nil
@@ -203,21 +187,21 @@ func (e *Executor) runBackupPhase() error {
 func (e *Executor) runPrunePhase() error {
 	e.log.Info("Starting prune phase.")
 
-	if e.plan.Request.DryRun {
+	if e.plan.DryRun {
 		e.log.DryRun("duplicacy list -files")
 	} else {
 		if err := e.dup.ValidateRepo(); err != nil {
-			return fmt.Errorf("Cannot perform prune operation — repository not ready: %w.", err)
+			return err
 		}
 		e.log.Info("Duplicacy repository validated.")
 	}
 
-	if e.plan.Request.DryRun {
-		e.log.DryRun("duplicacy prune %s -dry-run", strings.Join(e.plan.Config.PruneArgs, " "))
+	if e.plan.DryRun {
+		e.log.DryRun("duplicacy prune %s -dry-run", e.plan.PruneArgsDisplay)
 	}
-	preview, err := e.dup.SafePrunePreview(e.plan.Config.PruneArgs, e.plan.Config.SafePruneMinTotalForPercent)
+	preview, err := e.dup.SafePrunePreview(e.plan.PruneArgs, e.plan.SafePruneMinTotalForPercent)
 	if err != nil {
-		return fmt.Errorf("Safe prune preview failed: %w.", err)
+		return err
 	}
 
 	if preview.Output != "" {
@@ -239,56 +223,50 @@ func (e *Executor) runPrunePhase() error {
 		if e.plan.Request.ForcePrune {
 			e.log.Warn("Revision count failed; proceeding because --force-prune was supplied (percentage threshold not enforced).")
 		} else {
-			return fmt.Errorf("Revision count is required for safe prune but failed; use --force-prune to override.")
+			return NewMessageError("Revision count is required for safe prune but failed; use --force-prune to override.")
 		}
 	}
 
-	e.log.PrintLine("Preview Deletes", fmt.Sprintf("%d", preview.DeleteCount))
-	e.log.PrintLine("Preview Total Revs", fmt.Sprintf("%d", preview.TotalRevisions))
-	if preview.PercentEnforced {
-		e.log.PrintLine("Preview Delete %", fmt.Sprintf("%d", preview.DeletePercent))
-	} else {
-		e.log.PrintLine("Preview Delete %", fmt.Sprintf("<not enforced; total revisions unavailable or below %d>", e.plan.Config.SafePruneMinTotalForPercent))
-	}
+	e.view.PrintPrunePreview(preview, e.plan.SafePruneMinTotalForPercent)
 
 	blocked := false
-	if preview.DeleteCount > e.plan.Config.SafePruneMaxDeleteCount {
-		e.log.Error("Safe prune preview exceeds delete count threshold: %d > %d.", preview.DeleteCount, e.plan.Config.SafePruneMaxDeleteCount)
+	if preview.DeleteCount > e.plan.SafePruneMaxDeleteCount {
+		e.log.Error("Safe prune preview exceeds delete count threshold: %d > %d.", preview.DeleteCount, e.plan.SafePruneMaxDeleteCount)
 		blocked = true
 	}
-	if preview.ExceedsPercent(e.plan.Config.SafePruneMaxDeletePercent) {
-		e.log.Error("Safe prune preview exceeds delete percentage threshold (%d of %d revisions > %d%%).", preview.DeleteCount, preview.TotalRevisions, e.plan.Config.SafePruneMaxDeletePercent)
+	if preview.ExceedsPercent(e.plan.SafePruneMaxDeletePercent) {
+		e.log.Error("Safe prune preview exceeds delete percentage threshold (%d of %d revisions > %d%%).", preview.DeleteCount, preview.TotalRevisions, e.plan.SafePruneMaxDeletePercent)
 		blocked = true
 	}
 	if blocked {
-		if e.plan.Request.ForcePrune {
+		if e.plan.ForcePrune {
 			e.log.Warn("Proceeding despite safe prune threshold breach because --force-prune was supplied.")
 		} else {
-			return fmt.Errorf("Refusing to continue because safe prune thresholds were exceeded.")
+			return NewMessageError("Refusing to continue because safe prune thresholds were exceeded.")
 		}
 	}
 
 	e.log.Info("Starting policy prune.")
-	if e.plan.Request.DryRun {
-		e.log.DryRun("duplicacy prune %s", strings.Join(e.plan.Config.PruneArgs, " "))
+	if e.plan.DryRun {
+		e.log.DryRun("duplicacy prune %s", e.plan.PruneArgsDisplay)
 	} else {
-		stdout, stderr, err := e.dup.RunPrune(e.plan.Config.PruneArgs)
-		e.printCommandOutput(stdout, stderr)
+		stdout, stderr, err := e.dup.RunPrune(e.plan.PruneArgs)
+		e.view.PrintCommandOutput(stdout, stderr)
 		if err != nil {
-			return fmt.Errorf("Policy prune failed: %w.", err)
+			return err
 		}
 	}
 	e.log.Info("Policy prune completed.")
 
-	if e.plan.Request.DeepPruneMode {
+	if e.plan.DeepPruneMode {
 		e.log.Warn("Starting deep prune maintenance step: duplicacy prune -exhaustive -exclusive.")
-		if e.plan.Request.DryRun {
+		if e.plan.DryRun {
 			e.log.DryRun("duplicacy prune -exhaustive -exclusive")
 		} else {
 			stdout, stderr, err := e.dup.RunDeepPrune()
-			e.printCommandOutput(stdout, stderr)
+			e.view.PrintCommandOutput(stdout, stderr)
 			if err != nil {
-				return fmt.Errorf("Deep prune failed: %w.", err)
+				return err
 			}
 		}
 		e.log.Info("Deep prune completed.")
@@ -301,11 +279,11 @@ func (e *Executor) runPrunePhase() error {
 func (e *Executor) runFixPermsPhase() error {
 	e.log.Info("Starting permission normalisation on %s.", e.plan.BackupTarget)
 	e.log.PrintLine("Fix Perms Path", e.plan.BackupTarget)
-	e.log.PrintLine("Fix Perms Owner", e.plan.Config.LocalOwner)
-	e.log.PrintLine("Fix Perms Group", e.plan.Config.LocalGroup)
+	e.log.PrintLine("Fix Perms Owner", e.plan.LocalOwner)
+	e.log.PrintLine("Fix Perms Group", e.plan.LocalGroup)
 
-	if e.plan.Request.DryRun {
-		ownerGroup := fmt.Sprintf("%s:%s", e.plan.Config.LocalOwner, e.plan.Config.LocalGroup)
+	if e.plan.DryRun {
+		ownerGroup := fmt.Sprintf("%s:%s", e.plan.LocalOwner, e.plan.LocalGroup)
 		e.log.DryRun("chown -R %s %s", ownerGroup, e.plan.BackupTarget)
 		e.log.DryRun("find %s -type d -exec chmod 770 {} +", e.plan.BackupTarget)
 		e.log.DryRun("find %s -type f -exec chmod 660 {} +", e.plan.BackupTarget)
@@ -313,8 +291,8 @@ func (e *Executor) runFixPermsPhase() error {
 		return nil
 	}
 
-	if err := permissions.Fix(e.runner, e.plan.BackupTarget, e.plan.Config.LocalOwner, e.plan.Config.LocalGroup, false); err != nil {
-		return fmt.Errorf("Permission normalisation failed: %w.", err)
+	if err := permissions.Fix(e.runner, e.plan.BackupTarget, e.plan.LocalOwner, e.plan.LocalGroup, false); err != nil {
+		return err
 	}
 	e.log.Info("Permission normalisation completed successfully.")
 	return nil
@@ -328,10 +306,10 @@ func (e *Executor) cleanup() {
 
 	e.log.Info("Starting cleanup.")
 
-	if e.plan.Request.DoBackup {
+	if e.plan.NeedsSnapshot {
 		if _, err := os.Stat(e.plan.SnapshotTarget); err == nil {
 			e.log.Info("Deleting snapshot subvolume: %s.", e.plan.SnapshotTarget)
-			if e.plan.Request.DryRun {
+			if e.plan.DryRun {
 				e.log.DryRun("btrfs subvolume delete %s", e.plan.SnapshotTarget)
 			} else if delErr := btrfs.DeleteSnapshot(e.runner, e.plan.SnapshotTarget, false); delErr != nil {
 				e.log.Warn("Failed to delete subvolume %s: %v.", e.plan.SnapshotTarget, delErr)
@@ -340,7 +318,7 @@ func (e *Executor) cleanup() {
 
 		if _, err := os.Stat(e.plan.SnapshotTarget); err == nil {
 			e.log.Info("Removing snapshot directory: %s.", e.plan.SnapshotTarget)
-			if e.plan.Request.DryRun {
+			if e.plan.DryRun {
 				e.log.DryRun("rm -rf %s", e.plan.SnapshotTarget)
 			} else if rmErr := os.RemoveAll(e.plan.SnapshotTarget); rmErr != nil {
 				e.log.Warn("Failed to remove snapshot directory %s.", e.plan.SnapshotTarget)
@@ -350,14 +328,14 @@ func (e *Executor) cleanup() {
 
 	if e.dup != nil {
 		e.log.Info("Removing duplicacy work directory: %s.", e.dup.WorkRoot)
-		if e.plan.Request.DryRun {
+		if e.plan.DryRun {
 			e.log.DryRun("rm -rf %s", e.dup.WorkRoot)
 		} else if err := e.dup.Cleanup(); err != nil {
 			e.log.Warn("Failed to remove work directory: %v.", err)
 		}
 	} else if _, err := os.Stat(e.plan.WorkRoot); err == nil {
 		e.log.Info("Removing duplicacy work directory: %s.", e.plan.WorkRoot)
-		if e.plan.Request.DryRun {
+		if e.plan.DryRun {
 			e.log.DryRun("rm -rf %s", e.plan.WorkRoot)
 		} else if rmErr := os.RemoveAll(e.plan.WorkRoot); rmErr != nil {
 			e.log.Warn("Failed to remove work directory %s: %v.", e.plan.WorkRoot, rmErr)
@@ -368,37 +346,11 @@ func (e *Executor) cleanup() {
 		e.lock.Release()
 	}
 
-	status := "SUCCESS"
-	if e.exitCode != 0 {
-		status = "FAILED"
-	}
-	e.log.PrintSeparator()
-	e.log.Info("Backup script completed:")
-	e.log.PrintLine("Result", e.log.FormatResult(status))
-	e.log.PrintLine("Code", fmt.Sprintf("%d", e.exitCode))
-	e.log.PrintLine("Timestamp", e.rt.Now().Format("2006-01-02 15:04:05"))
-	e.log.PrintSeparator()
+	e.view.PrintCompletion(e.exitCode)
 	e.log.Close()
 }
 
 func (e *Executor) fail(err error) {
-	e.log.Error("%v", err)
+	e.log.Error("%s", OperatorMessage(err))
 	e.exitCode = 1
-}
-
-func (e *Executor) printCommandOutput(stdout, stderr string) {
-	if stdout != "" {
-		for _, line := range strings.Split(strings.TrimRight(stdout, "\n"), "\n") {
-			if line != "" {
-				e.log.Info("%s", line)
-			}
-		}
-	}
-	if stderr != "" {
-		for _, line := range strings.Split(strings.TrimRight(stderr, "\n"), "\n") {
-			if line != "" {
-				e.log.Warn("%s", line)
-			}
-		}
-	}
 }

--- a/internal/workflow/executor_test.go
+++ b/internal/workflow/executor_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/config"
+	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/duplicacy"
 	execpkg "github.com/phillipmcmahon/synology-duplicacy-backup/internal/exec"
 	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/lock"
 	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/logger"
@@ -47,22 +47,21 @@ func TestExecutorRun_FixPermsOnlyDryRun(t *testing.T) {
 	rt.SignalNotify = func(chan<- os.Signal, ...os.Signal) {}
 
 	plan := &Plan{
-		Request: &Request{
-			FixPerms:      true,
-			FixPermsOnly:  true,
-			DryRun:        true,
-			DefaultNotice: "No primary mode specified: using fix-perms only.",
-		},
-		Config: &config.Config{
-			Destination:      "/backups",
-			LocalOwner:       u.Username,
-			LocalGroup:       g.Name,
-			LogRetentionDays: 30,
-		},
-		BackupLabel:   "homes",
-		BackupTarget:  "/backups/homes",
-		WorkRoot:      filepath.Join(t.TempDir(), "work"),
-		OperationMode: "Fix permissions only",
+		FixPerms:                 true,
+		FixPermsOnly:             true,
+		DryRun:                   true,
+		DefaultNotice:            "No primary mode specified: using fix-perms only.",
+		LogRetentionDays:         30,
+		LocalOwner:               u.Username,
+		LocalGroup:               g.Name,
+		OwnerGroup:               u.Username + ":" + g.Name,
+		BackupLabel:              "homes",
+		BackupTarget:             "/backups/homes",
+		WorkRoot:                 filepath.Join(t.TempDir(), "work"),
+		OperationMode:            "Fix permissions only",
+		FixPermsChownCommand:     "chown -R " + u.Username + ":" + g.Name + " /backups/homes",
+		FixPermsDirPermsCommand:  "find /backups/homes -type d -exec chmod 770 {} +",
+		FixPermsFilePermsCommand: "find /backups/homes -type f -exec chmod 660 {} +",
 	}
 
 	executor := NewExecutor(DefaultMetadata("duplicacy-backup", "1.0.0", "now", t.TempDir()), rt, testExecutorLogger(t), execpkg.NewMockRunner(), plan)
@@ -71,5 +70,27 @@ func TestExecutorRun_FixPermsOnlyDryRun(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(lockParent, "backup-homes.lock.d")); !os.IsNotExist(err) {
 		t.Fatalf("expected lock directory cleanup, stat err = %v", err)
+	}
+}
+
+func TestExecutor_EnforcePrunePreview_ThresholdExceededWithoutForce(t *testing.T) {
+	plan := &Plan{
+		SafePruneMaxDeleteCount:   1,
+		SafePruneMaxDeletePercent: 10,
+	}
+	executor := NewExecutor(DefaultMetadata("duplicacy-backup", "1.0.0", "now", t.TempDir()), testRuntime(), testExecutorLogger(t), execpkg.NewMockRunner(), plan)
+
+	preview := &duplicacy.PrunePreview{
+		DeleteCount:     2,
+		TotalRevisions:  10,
+		PercentEnforced: true,
+	}
+
+	err := executor.enforcePrunePreview(preview)
+	if err == nil {
+		t.Fatal("expected prune threshold error")
+	}
+	if got := OperatorMessage(err); got != "Refusing to continue because safe prune thresholds were exceeded." {
+		t.Fatalf("OperatorMessage() = %q", got)
 	}
 }

--- a/internal/workflow/messages.go
+++ b/internal/workflow/messages.go
@@ -90,5 +90,29 @@ func OperatorMessage(err error) string {
 		return "Permission normalisation failed."
 	}
 
+	var configErr *apperrors.ConfigError
+	if errors.As(err, &configErr) {
+		if configErr.Cause != nil {
+			return configErr.Cause.Error()
+		}
+		return configErr.Error()
+	}
+
+	var secretsErr *apperrors.SecretsError
+	if errors.As(err, &secretsErr) {
+		if secretsErr.Cause != nil {
+			return secretsErr.Cause.Error()
+		}
+		return secretsErr.Error()
+	}
+
+	var lockErr *apperrors.LockError
+	if errors.As(err, &lockErr) {
+		if lockErr.Cause != nil {
+			return fmt.Sprintf("Lock acquisition failed: %s", lockErr.Cause.Error())
+		}
+		return "Lock acquisition failed."
+	}
+
 	return err.Error()
 }

--- a/internal/workflow/messages.go
+++ b/internal/workflow/messages.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	apperrors "github.com/phillipmcmahon/synology-duplicacy-backup/internal/errors"
 )
@@ -31,29 +32,29 @@ func OperatorMessage(err error) string {
 
 	var msgErr *MessageError
 	if errors.As(err, &msgErr) {
-		return msgErr.Message
+		return normaliseOperatorSentence(msgErr.Message)
 	}
 
 	var requestErr *RequestError
 	if errors.As(err, &requestErr) {
-		return requestErr.Error()
+		return normaliseOperatorSentence(requestErr.Error())
 	}
 
 	var backupErr *apperrors.BackupError
 	if errors.As(err, &backupErr) {
 		switch backupErr.Phase {
 		case "create-dirs":
-			return "Failed to create Duplicacy directories."
+			return normaliseOperatorSentence("Failed to create Duplicacy directories.")
 		case "write-preferences":
-			return "Failed to write preferences."
+			return normaliseOperatorSentence("Failed to write preferences.")
 		case "write-filters":
-			return "Failed to write filter file."
+			return normaliseOperatorSentence("Failed to write filter file.")
 		case "set-permissions":
-			return "Failed to set permissions in the Duplicacy work directory."
+			return normaliseOperatorSentence("Failed to set permissions in the Duplicacy work directory.")
 		case "run":
-			return "Backup failed."
+			return normaliseOperatorSentence("Backup failed.")
 		default:
-			return backupErr.Error()
+			return normaliseOperatorSentence(backupErr.Error())
 		}
 	}
 
@@ -61,15 +62,15 @@ func OperatorMessage(err error) string {
 	if errors.As(err, &pruneErr) {
 		switch pruneErr.Phase {
 		case "validate-repo":
-			return "Cannot perform prune operation — repository not ready."
+			return normaliseOperatorSentence("Cannot perform prune operation — repository not ready.")
 		case "safe-preview":
-			return "Safe prune preview failed."
+			return normaliseOperatorSentence("Safe prune preview failed.")
 		case "run":
-			return "Policy prune failed."
+			return normaliseOperatorSentence("Policy prune failed.")
 		case "deep-prune":
-			return "Deep prune failed."
+			return normaliseOperatorSentence("Deep prune failed.")
 		default:
-			return pruneErr.Error()
+			return normaliseOperatorSentence(pruneErr.Error())
 		}
 	}
 
@@ -77,42 +78,81 @@ func OperatorMessage(err error) string {
 	if errors.As(err, &snapshotErr) {
 		switch snapshotErr.Phase {
 		case "create":
-			return "Failed to create snapshot."
+			return normaliseOperatorSentence("Failed to create snapshot.")
 		case "delete":
-			return "Failed to delete snapshot subvolume."
+			return normaliseOperatorSentence("Failed to delete snapshot subvolume.")
 		default:
-			return snapshotErr.Error()
+			return normaliseOperatorSentence(snapshotErr.Error())
 		}
 	}
 
 	var permissionsErr *apperrors.PermissionsError
 	if errors.As(err, &permissionsErr) {
-		return "Permission normalisation failed."
+		return normaliseOperatorSentence("Permission normalisation failed.")
 	}
 
 	var configErr *apperrors.ConfigError
 	if errors.As(err, &configErr) {
-		if configErr.Cause != nil {
-			return configErr.Cause.Error()
-		}
-		return configErr.Error()
+		return normaliseOperatorSentence(operatorConfigMessage(configErr))
 	}
 
 	var secretsErr *apperrors.SecretsError
 	if errors.As(err, &secretsErr) {
-		if secretsErr.Cause != nil {
-			return secretsErr.Cause.Error()
-		}
-		return secretsErr.Error()
+		return normaliseOperatorSentence(operatorSecretsMessage(secretsErr))
 	}
 
 	var lockErr *apperrors.LockError
 	if errors.As(err, &lockErr) {
 		if lockErr.Cause != nil {
-			return fmt.Sprintf("Lock acquisition failed: %s", lockErr.Cause.Error())
+			return normaliseOperatorSentence(fmt.Sprintf("Lock acquisition failed: %s", lockErr.Cause.Error()))
 		}
-		return "Lock acquisition failed."
+		return normaliseOperatorSentence("Lock acquisition failed.")
 	}
 
+	return normaliseOperatorSentence(err.Error())
+}
+
+func operatorConfigMessage(err *apperrors.ConfigError) string {
+	switch err.Field {
+	case "open",
+		"read",
+		"section-common",
+		"section-target",
+		"required",
+		"threads",
+		"log-retention-days",
+		"safe-prune-max-delete-percent",
+		"safe-prune-max-delete-count",
+		"safe-prune-min-total-for-percent",
+		"local-owner",
+		"local-group",
+		"parse":
+		if err.Cause != nil {
+			return err.Cause.Error()
+		}
+	}
 	return err.Error()
+}
+
+func operatorSecretsMessage(err *apperrors.SecretsError) string {
+	switch err.Phase {
+	case "stat", "permissions", "ownership", "parse", "read", "required", "open", "validate":
+		if err.Cause != nil {
+			return err.Cause.Error()
+		}
+	}
+	return err.Error()
+}
+
+func normaliseOperatorSentence(message string) string {
+	message = strings.TrimSpace(message)
+	if message == "" {
+		return ""
+	}
+	switch message[len(message)-1] {
+	case '.', '!', '?':
+		return message
+	default:
+		return message + "."
+	}
 }

--- a/internal/workflow/messages.go
+++ b/internal/workflow/messages.go
@@ -1,0 +1,94 @@
+package workflow
+
+import (
+	"errors"
+	"fmt"
+
+	apperrors "github.com/phillipmcmahon/synology-duplicacy-backup/internal/errors"
+)
+
+// MessageError represents a workflow-owned operator message that should be
+// logged as-is without additional translation.
+type MessageError struct {
+	Message string
+}
+
+func (e *MessageError) Error() string {
+	return e.Message
+}
+
+func NewMessageError(format string, args ...interface{}) error {
+	return &MessageError{Message: fmt.Sprintf(format, args...)}
+}
+
+// OperatorMessage translates internal errors into consistent operator-facing
+// messages. Domain packages can keep returning rich typed errors while the
+// workflow layer remains the single owner of final wording.
+func OperatorMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var msgErr *MessageError
+	if errors.As(err, &msgErr) {
+		return msgErr.Message
+	}
+
+	var requestErr *RequestError
+	if errors.As(err, &requestErr) {
+		return requestErr.Error()
+	}
+
+	var backupErr *apperrors.BackupError
+	if errors.As(err, &backupErr) {
+		switch backupErr.Phase {
+		case "create-dirs":
+			return "Failed to create Duplicacy directories."
+		case "write-preferences":
+			return "Failed to write preferences."
+		case "write-filters":
+			return "Failed to write filter file."
+		case "set-permissions":
+			return "Failed to set permissions in the Duplicacy work directory."
+		case "run":
+			return "Backup failed."
+		default:
+			return backupErr.Error()
+		}
+	}
+
+	var pruneErr *apperrors.PruneError
+	if errors.As(err, &pruneErr) {
+		switch pruneErr.Phase {
+		case "validate-repo":
+			return "Cannot perform prune operation — repository not ready."
+		case "safe-preview":
+			return "Safe prune preview failed."
+		case "run":
+			return "Policy prune failed."
+		case "deep-prune":
+			return "Deep prune failed."
+		default:
+			return pruneErr.Error()
+		}
+	}
+
+	var snapshotErr *apperrors.SnapshotError
+	if errors.As(err, &snapshotErr) {
+		switch snapshotErr.Phase {
+		case "create":
+			return "Failed to create snapshot."
+		case "delete":
+			return "Failed to delete snapshot subvolume."
+		default:
+			return snapshotErr.Error()
+		}
+	}
+
+	var permissionsErr *apperrors.PermissionsError
+	if errors.As(err, &permissionsErr) {
+		return "Permission normalisation failed."
+	}
+
+	return err.Error()
+}

--- a/internal/workflow/messages.go
+++ b/internal/workflow/messages.go
@@ -69,6 +69,11 @@ func OperatorMessage(err error) string {
 			return normaliseOperatorSentence("Policy prune failed.")
 		case "deep-prune":
 			return normaliseOperatorSentence("Deep prune failed.")
+		case "revision-count":
+			if pruneErr.Cause != nil {
+				return normaliseOperatorSentence(pruneErr.Cause.Error())
+			}
+			return normaliseOperatorSentence(pruneErr.Error())
 		default:
 			return normaliseOperatorSentence(pruneErr.Error())
 		}
@@ -81,6 +86,11 @@ func OperatorMessage(err error) string {
 			return normaliseOperatorSentence("Failed to create snapshot.")
 		case "delete":
 			return normaliseOperatorSentence("Failed to delete snapshot subvolume.")
+		case "check-volume":
+			if snapshotErr.Cause != nil {
+				return normaliseOperatorSentence(snapshotErr.Cause.Error())
+			}
+			return normaliseOperatorSentence(snapshotErr.Error())
 		default:
 			return normaliseOperatorSentence(snapshotErr.Error())
 		}
@@ -150,9 +160,13 @@ func normaliseOperatorSentence(message string) string {
 		return ""
 	}
 	switch message[len(message)-1] {
-	case '.', '!', '?':
+	case '.', '!', '?', ':':
 		return message
 	default:
 		return message + "."
 	}
+}
+
+func statusLinef(format string, args ...interface{}) string {
+	return normaliseOperatorSentence(fmt.Sprintf(format, args...))
 }

--- a/internal/workflow/messages_test.go
+++ b/internal/workflow/messages_test.go
@@ -27,3 +27,24 @@ func TestOperatorMessage_MessageError(t *testing.T) {
 		t.Fatalf("OperatorMessage() = %q", got)
 	}
 }
+
+func TestOperatorMessage_ConfigErrorUsesCause(t *testing.T) {
+	err := apperrors.NewConfigError("threads", errors.New("THREADS must be a power of 2 and <= 16 (was 3)"))
+	if got := OperatorMessage(err); got != "THREADS must be a power of 2 and <= 16 (was 3)" {
+		t.Fatalf("OperatorMessage() = %q", got)
+	}
+}
+
+func TestOperatorMessage_SecretsErrorUsesCause(t *testing.T) {
+	err := apperrors.NewSecretsError("validate", errors.New("STORJ_S3_ID must be at least 28 characters (was 5)"))
+	if got := OperatorMessage(err); got != "STORJ_S3_ID must be at least 28 characters (was 5)" {
+		t.Fatalf("OperatorMessage() = %q", got)
+	}
+}
+
+func TestOperatorMessage_LockErrorPrefixed(t *testing.T) {
+	err := apperrors.NewLockError("held", errors.New("another backup is already running (PID: 123)"))
+	if got := OperatorMessage(err); got != "Lock acquisition failed: another backup is already running (PID: 123)" {
+		t.Fatalf("OperatorMessage() = %q", got)
+	}
+}

--- a/internal/workflow/messages_test.go
+++ b/internal/workflow/messages_test.go
@@ -19,14 +19,29 @@ func TestOperatorMessage(t *testing.T) {
 			want: "Backup failed.",
 		},
 		{
+			name: "backup write preferences translated",
+			err:  apperrors.NewBackupError("write-preferences", errors.New("failed to write preferences file: permission denied")),
+			want: "Failed to write preferences.",
+		},
+		{
 			name: "prune validate repo",
 			err:  apperrors.NewPruneError("validate-repo", errors.New("boom")),
 			want: "Cannot perform prune operation — repository not ready.",
 		},
 		{
+			name: "prune revision count fallback cause",
+			err:  apperrors.NewPruneError("revision-count", errors.New("failed to list revisions for percentage calculation (fail-closed)")),
+			want: "failed to list revisions for percentage calculation (fail-closed).",
+		},
+		{
 			name: "message error",
 			err:  NewMessageError("Refusing to continue because safe prune thresholds were exceeded."),
 			want: "Refusing to continue because safe prune thresholds were exceeded.",
+		},
+		{
+			name: "snapshot check volume cause",
+			err:  apperrors.NewSnapshotError("check-volume", errors.New("path is not on a btrfs filesystem")),
+			want: "path is not on a btrfs filesystem.",
 		},
 		{
 			name: "config required fields",

--- a/internal/workflow/messages_test.go
+++ b/internal/workflow/messages_test.go
@@ -1,0 +1,29 @@
+package workflow
+
+import (
+	"errors"
+	"testing"
+
+	apperrors "github.com/phillipmcmahon/synology-duplicacy-backup/internal/errors"
+)
+
+func TestOperatorMessage_BackupRun(t *testing.T) {
+	err := apperrors.NewBackupError("run", errors.New("boom"))
+	if got := OperatorMessage(err); got != "Backup failed." {
+		t.Fatalf("OperatorMessage() = %q", got)
+	}
+}
+
+func TestOperatorMessage_PruneValidateRepo(t *testing.T) {
+	err := apperrors.NewPruneError("validate-repo", errors.New("boom"))
+	if got := OperatorMessage(err); got != "Cannot perform prune operation — repository not ready." {
+		t.Fatalf("OperatorMessage() = %q", got)
+	}
+}
+
+func TestOperatorMessage_MessageError(t *testing.T) {
+	err := NewMessageError("Refusing to continue because safe prune thresholds were exceeded.")
+	if got := OperatorMessage(err); got != "Refusing to continue because safe prune thresholds were exceeded." {
+		t.Fatalf("OperatorMessage() = %q", got)
+	}
+}

--- a/internal/workflow/messages_test.go
+++ b/internal/workflow/messages_test.go
@@ -7,44 +7,59 @@ import (
 	apperrors "github.com/phillipmcmahon/synology-duplicacy-backup/internal/errors"
 )
 
-func TestOperatorMessage_BackupRun(t *testing.T) {
-	err := apperrors.NewBackupError("run", errors.New("boom"))
-	if got := OperatorMessage(err); got != "Backup failed." {
-		t.Fatalf("OperatorMessage() = %q", got)
+func TestOperatorMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "backup run",
+			err:  apperrors.NewBackupError("run", errors.New("boom")),
+			want: "Backup failed.",
+		},
+		{
+			name: "prune validate repo",
+			err:  apperrors.NewPruneError("validate-repo", errors.New("boom")),
+			want: "Cannot perform prune operation — repository not ready.",
+		},
+		{
+			name: "message error",
+			err:  NewMessageError("Refusing to continue because safe prune thresholds were exceeded."),
+			want: "Refusing to continue because safe prune thresholds were exceeded.",
+		},
+		{
+			name: "config required fields",
+			err:  apperrors.NewConfigError("required", errors.New("missing required config variables: DESTINATION, THREADS")),
+			want: "missing required config variables: DESTINATION, THREADS.",
+		},
+		{
+			name: "config owner validation",
+			err:  apperrors.NewConfigError("local-owner", errors.New("LOCAL_OWNER is mandatory: set it in your .conf file to the non-root user that should own backup files (e.g. LOCAL_OWNER=myuser)")),
+			want: "LOCAL_OWNER is mandatory: set it in your .conf file to the non-root user that should own backup files (e.g. LOCAL_OWNER=myuser).",
+		},
+		{
+			name: "secrets validate",
+			err:  apperrors.NewSecretsError("validate", errors.New("STORJ_S3_ID must be at least 28 characters (was 5)")),
+			want: "STORJ_S3_ID must be at least 28 characters (was 5).",
+		},
+		{
+			name: "secrets permissions",
+			err:  apperrors.NewSecretsError("permissions", errors.New("secrets file permissions are 0644, expected 0600: /tmp/test.env")),
+			want: "secrets file permissions are 0644, expected 0600: /tmp/test.env.",
+		},
+		{
+			name: "lock held",
+			err:  apperrors.NewLockError("held", errors.New("another backup is already running (PID: 123)")),
+			want: "Lock acquisition failed: another backup is already running (PID: 123).",
+		},
 	}
-}
 
-func TestOperatorMessage_PruneValidateRepo(t *testing.T) {
-	err := apperrors.NewPruneError("validate-repo", errors.New("boom"))
-	if got := OperatorMessage(err); got != "Cannot perform prune operation — repository not ready." {
-		t.Fatalf("OperatorMessage() = %q", got)
-	}
-}
-
-func TestOperatorMessage_MessageError(t *testing.T) {
-	err := NewMessageError("Refusing to continue because safe prune thresholds were exceeded.")
-	if got := OperatorMessage(err); got != "Refusing to continue because safe prune thresholds were exceeded." {
-		t.Fatalf("OperatorMessage() = %q", got)
-	}
-}
-
-func TestOperatorMessage_ConfigErrorUsesCause(t *testing.T) {
-	err := apperrors.NewConfigError("threads", errors.New("THREADS must be a power of 2 and <= 16 (was 3)"))
-	if got := OperatorMessage(err); got != "THREADS must be a power of 2 and <= 16 (was 3)" {
-		t.Fatalf("OperatorMessage() = %q", got)
-	}
-}
-
-func TestOperatorMessage_SecretsErrorUsesCause(t *testing.T) {
-	err := apperrors.NewSecretsError("validate", errors.New("STORJ_S3_ID must be at least 28 characters (was 5)"))
-	if got := OperatorMessage(err); got != "STORJ_S3_ID must be at least 28 characters (was 5)" {
-		t.Fatalf("OperatorMessage() = %q", got)
-	}
-}
-
-func TestOperatorMessage_LockErrorPrefixed(t *testing.T) {
-	err := apperrors.NewLockError("held", errors.New("another backup is already running (PID: 123)"))
-	if got := OperatorMessage(err); got != "Lock acquisition failed: another backup is already running (PID: 123)" {
-		t.Fatalf("OperatorMessage() = %q", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := OperatorMessage(tt.err); got != tt.want {
+				t.Fatalf("OperatorMessage() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/workflow/permissions_exec.go
+++ b/internal/workflow/permissions_exec.go
@@ -1,0 +1,26 @@
+package workflow
+
+import (
+	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/permissions"
+)
+
+func (e *Executor) runFixPermsPhase() error {
+	e.log.Info("%s", statusLinef("Starting permission normalisation on %s.", e.plan.BackupTarget))
+	e.log.PrintLine("Fix Perms Path", e.plan.BackupTarget)
+	e.log.PrintLine("Fix Perms Owner", e.plan.LocalOwner)
+	e.log.PrintLine("Fix Perms Group", e.plan.LocalGroup)
+
+	if e.plan.DryRun {
+		e.log.DryRun("%s", e.plan.FixPermsChownCommand)
+		e.log.DryRun("%s", e.plan.FixPermsDirPermsCommand)
+		e.log.DryRun("%s", e.plan.FixPermsFilePermsCommand)
+		e.log.Info("%s", statusLinef("Permission normalisation completed (dry-run)."))
+		return nil
+	}
+
+	if err := permissions.Fix(e.runner, e.plan.BackupTarget, e.plan.LocalOwner, e.plan.LocalGroup, false); err != nil {
+		return err
+	}
+	e.log.Info("%s", statusLinef("Permission normalisation completed successfully."))
+	return nil
+}

--- a/internal/workflow/plan.go
+++ b/internal/workflow/plan.go
@@ -3,13 +3,10 @@ package workflow
 import (
 	"path/filepath"
 
-	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/config"
 	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/secrets"
 )
 
 type Plan struct {
-	Request *Request
-	Config  *config.Config
 	Secrets *secrets.Secrets
 
 	DoBackup      bool
@@ -47,6 +44,7 @@ type Plan struct {
 	Threads                     int
 	Filter                      string
 	FilterLines                 []string
+	OwnerGroup                  string
 	PruneOptions                string
 	PruneArgs                   []string
 	PruneArgsDisplay            string
@@ -56,6 +54,23 @@ type Plan struct {
 	SafePruneMaxDeletePercent   int
 	SafePruneMaxDeleteCount     int
 	SafePruneMinTotalForPercent int
+
+	SnapshotCreateCommand    string
+	SnapshotDeleteCommand    string
+	WorkDirCreateCommand     string
+	PreferencesWriteCommand  string
+	FiltersWriteCommand      string
+	WorkDirDirPermsCommand   string
+	WorkDirFilePermsCommand  string
+	BackupCommand            string
+	ValidateRepoCommand      string
+	PrunePreviewCommand      string
+	PolicyPruneCommand       string
+	DeepPruneCommand         string
+	FixPermsChownCommand     string
+	FixPermsDirPermsCommand  string
+	FixPermsFilePermsCommand string
+	WorkDirRemoveCommand     string
 }
 
 func (p *Plan) IsRemote() bool {

--- a/internal/workflow/plan.go
+++ b/internal/workflow/plan.go
@@ -12,6 +12,21 @@ type Plan struct {
 	Config  *config.Config
 	Secrets *secrets.Secrets
 
+	DoBackup      bool
+	DoPrune       bool
+	DeepPruneMode bool
+	FixPerms      bool
+	FixPermsOnly  bool
+	ForcePrune    bool
+	RemoteMode    bool
+	DryRun        bool
+
+	NeedsDuplicacySetup bool
+	NeedsSnapshot       bool
+
+	DefaultNotice string
+	ModeDisplay   string
+
 	BackupLabel    string
 	RunTimestamp   string
 	SnapshotSource string
@@ -27,17 +42,28 @@ type Plan struct {
 	SecretsFile string
 
 	OperationMode string
+	Summary       []SummaryLine
+
+	Threads                     int
+	Filter                      string
+	FilterLines                 []string
+	PruneOptions                string
+	PruneArgs                   []string
+	PruneArgsDisplay            string
+	LocalOwner                  string
+	LocalGroup                  string
+	LogRetentionDays            int
+	SafePruneMaxDeletePercent   int
+	SafePruneMaxDeleteCount     int
+	SafePruneMinTotalForPercent int
 }
 
 func (p *Plan) IsRemote() bool {
-	return p.Request != nil && p.Request.RemoteMode
+	return p.RemoteMode
 }
 
 func (p *Plan) ModeLabel() string {
-	if p.IsRemote() {
-		return "REMOTE"
-	}
-	return "LOCAL"
+	return p.ModeDisplay
 }
 
 func (p *Plan) WorkDir() string {

--- a/internal/workflow/planner.go
+++ b/internal/workflow/planner.go
@@ -35,12 +35,12 @@ func (p *Planner) Build(req *Request) (*Plan, error) {
 	if err != nil {
 		return nil, err
 	}
-	plan.Config = cfg
 	plan.BackupTarget = JoinDestination(cfg.Destination, plan.BackupLabel)
 	plan.OperationMode = OperationMode(req)
 	plan.Threads = cfg.Threads
 	plan.Filter = cfg.Filter
 	plan.FilterLines = splitNonEmptyLines(cfg.Filter)
+	plan.OwnerGroup = fmt.Sprintf("%s:%s", cfg.LocalOwner, cfg.LocalGroup)
 	plan.PruneOptions = cfg.Prune
 	plan.PruneArgs = append([]string(nil), cfg.PruneArgs...)
 	plan.PruneArgsDisplay = strings.Join(cfg.PruneArgs, " ")
@@ -59,6 +59,7 @@ func (p *Planner) Build(req *Request) (*Plan, error) {
 		plan.Secrets = sec
 	}
 
+	p.populateCommands(plan)
 	plan.Summary = SummaryLines(plan)
 
 	return plan, nil
@@ -98,7 +99,6 @@ func (p *Planner) derivePlan(req *Request) *Plan {
 	secretsDir := ResolveDir(p.rt, req.SecretsDir, "DUPLICACY_BACKUP_SECRETS_DIR", config.DefaultSecretsDir)
 
 	return &Plan{
-		Request:             req,
 		DoBackup:            req.DoBackup,
 		DoPrune:             req.DoPrune,
 		DeepPruneMode:       req.DeepPruneMode,
@@ -134,7 +134,7 @@ func (p *Planner) loadConfig(plan *Plan) (*config.Config, error) {
 
 	cfg := config.NewDefaults()
 	targetSection := "local"
-	if plan.Request.RemoteMode {
+	if plan.RemoteMode {
 		targetSection = "remote"
 	}
 
@@ -148,28 +148,28 @@ func (p *Planner) loadConfig(plan *Plan) (*config.Config, error) {
 
 	p.log.Info("Configuration parsed for [common] + [%s].", targetSection)
 
-	if err := cfg.ValidateRequired(plan.Request.DoBackup, plan.Request.DoPrune); err != nil {
+	if err := cfg.ValidateRequired(plan.DoBackup, plan.DoPrune); err != nil {
 		return nil, err
 	}
 	if err := cfg.ValidateThresholds(); err != nil {
 		return nil, err
 	}
-	if plan.Request.FixPerms {
+	if plan.FixPerms {
 		if err := cfg.ValidateOwnerGroup(); err != nil {
 			return nil, err
 		}
 	}
 	cfg.BuildPruneArgs()
-	if plan.Request.DoBackup {
+	if plan.DoBackup {
 		if err := cfg.ValidateThreads(); err != nil {
 			return nil, err
 		}
-		if err := btrfs.CheckVolume(p.runner, p.meta.RootVolume, plan.Request.DryRun); err != nil {
+		if err := btrfs.CheckVolume(p.runner, p.meta.RootVolume, plan.DryRun); err != nil {
 			return nil, err
 		}
 		p.log.Info("Verified '%s' is on a btrfs filesystem.", p.meta.RootVolume)
 
-		if err := btrfs.CheckVolume(p.runner, plan.SnapshotSource, plan.Request.DryRun); err != nil {
+		if err := btrfs.CheckVolume(p.runner, plan.SnapshotSource, plan.DryRun); err != nil {
 			return nil, err
 		}
 		p.log.Info("Verified '%s' is on a btrfs filesystem.", plan.SnapshotSource)
@@ -177,6 +177,31 @@ func (p *Planner) loadConfig(plan *Plan) (*config.Config, error) {
 
 	p.log.Info("Configuration loaded successfully.")
 	return cfg, nil
+}
+
+func (p *Planner) populateCommands(plan *Plan) {
+	plan.SnapshotCreateCommand = fmt.Sprintf("btrfs subvolume snapshot -r %s %s", plan.SnapshotSource, plan.SnapshotTarget)
+	plan.SnapshotDeleteCommand = fmt.Sprintf("btrfs subvolume delete %s", plan.SnapshotTarget)
+	plan.WorkDirCreateCommand = fmt.Sprintf("mkdir -p %s", filepath.Join(plan.DuplicacyRoot, ".duplicacy"))
+	plan.PreferencesWriteCommand = fmt.Sprintf("write JSON preferences to %s", filepath.Join(plan.DuplicacyRoot, ".duplicacy", "preferences"))
+	plan.FiltersWriteCommand = fmt.Sprintf("write filters to %s", filepath.Join(plan.DuplicacyRoot, ".duplicacy", "filters"))
+	plan.WorkDirDirPermsCommand = fmt.Sprintf("find %s -type d -exec chmod 770 {} +", plan.DuplicacyRoot)
+	plan.WorkDirFilePermsCommand = fmt.Sprintf("find %s -type f -exec chmod 660 {} +", plan.DuplicacyRoot)
+	plan.BackupCommand = fmt.Sprintf("duplicacy backup -stats -threads %d", plan.Threads)
+	plan.ValidateRepoCommand = "duplicacy list -files"
+	plan.PrunePreviewCommand = strings.TrimSpace(fmt.Sprintf("duplicacy prune %s -dry-run", plan.PruneArgsDisplay))
+	if plan.PrunePreviewCommand == "duplicacy prune  -dry-run" {
+		plan.PrunePreviewCommand = "duplicacy prune -dry-run"
+	}
+	plan.PolicyPruneCommand = strings.TrimSpace(fmt.Sprintf("duplicacy prune %s", plan.PruneArgsDisplay))
+	if plan.PolicyPruneCommand == "duplicacy prune" || plan.PolicyPruneCommand == "duplicacy prune " {
+		plan.PolicyPruneCommand = "duplicacy prune"
+	}
+	plan.DeepPruneCommand = "duplicacy prune -exhaustive -exclusive"
+	plan.FixPermsChownCommand = fmt.Sprintf("chown -R %s %s", plan.OwnerGroup, plan.BackupTarget)
+	plan.FixPermsDirPermsCommand = fmt.Sprintf("find %s -type d -exec chmod 770 {} +", plan.BackupTarget)
+	plan.FixPermsFilePermsCommand = fmt.Sprintf("find %s -type f -exec chmod 660 {} +", plan.BackupTarget)
+	plan.WorkDirRemoveCommand = fmt.Sprintf("rm -rf %s", plan.WorkRoot)
 }
 
 func splitNonEmptyLines(value string) []string {

--- a/internal/workflow/planner.go
+++ b/internal/workflow/planner.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/btrfs"
 	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/config"
@@ -37,6 +38,18 @@ func (p *Planner) Build(req *Request) (*Plan, error) {
 	plan.Config = cfg
 	plan.BackupTarget = JoinDestination(cfg.Destination, plan.BackupLabel)
 	plan.OperationMode = OperationMode(req)
+	plan.Threads = cfg.Threads
+	plan.Filter = cfg.Filter
+	plan.FilterLines = splitNonEmptyLines(cfg.Filter)
+	plan.PruneOptions = cfg.Prune
+	plan.PruneArgs = append([]string(nil), cfg.PruneArgs...)
+	plan.PruneArgsDisplay = strings.Join(cfg.PruneArgs, " ")
+	plan.LocalOwner = cfg.LocalOwner
+	plan.LocalGroup = cfg.LocalGroup
+	plan.LogRetentionDays = cfg.LogRetentionDays
+	plan.SafePruneMaxDeletePercent = cfg.SafePruneMaxDeletePercent
+	plan.SafePruneMaxDeleteCount = cfg.SafePruneMaxDeleteCount
+	plan.SafePruneMinTotalForPercent = cfg.SafePruneMinTotalForPercent
 
 	if req.RemoteMode {
 		sec, err := p.loadSecrets(plan)
@@ -45,6 +58,8 @@ func (p *Planner) Build(req *Request) (*Plan, error) {
 		}
 		plan.Secrets = sec
 	}
+
+	plan.Summary = SummaryLines(plan)
 
 	return plan, nil
 }
@@ -83,18 +98,30 @@ func (p *Planner) derivePlan(req *Request) *Plan {
 	secretsDir := ResolveDir(p.rt, req.SecretsDir, "DUPLICACY_BACKUP_SECRETS_DIR", config.DefaultSecretsDir)
 
 	return &Plan{
-		Request:        req,
-		BackupLabel:    backupLabel,
-		RunTimestamp:   runTimestamp,
-		SnapshotSource: snapshotSource,
-		SnapshotTarget: snapshotTarget,
-		RepositoryPath: repositoryPath,
-		WorkRoot:       workRoot,
-		DuplicacyRoot:  filepath.Join(workRoot, "duplicacy"),
-		ConfigDir:      configDir,
-		ConfigFile:     filepath.Join(configDir, fmt.Sprintf("%s-backup.conf", backupLabel)),
-		SecretsDir:     secretsDir,
-		SecretsFile:    secrets.GetSecretsFilePath(secretsDir, config.DefaultSecretsPrefix, backupLabel),
+		Request:             req,
+		DoBackup:            req.DoBackup,
+		DoPrune:             req.DoPrune,
+		DeepPruneMode:       req.DeepPruneMode,
+		FixPerms:            req.FixPerms,
+		FixPermsOnly:        req.FixPermsOnly,
+		ForcePrune:          req.ForcePrune,
+		RemoteMode:          req.RemoteMode,
+		DryRun:              req.DryRun,
+		NeedsDuplicacySetup: req.DoBackup || req.DoPrune,
+		NeedsSnapshot:       req.DoBackup,
+		DefaultNotice:       req.DefaultNotice,
+		ModeDisplay:         modeDisplay(req.RemoteMode),
+		BackupLabel:         backupLabel,
+		RunTimestamp:        runTimestamp,
+		SnapshotSource:      snapshotSource,
+		SnapshotTarget:      snapshotTarget,
+		RepositoryPath:      repositoryPath,
+		WorkRoot:            workRoot,
+		DuplicacyRoot:       filepath.Join(workRoot, "duplicacy"),
+		ConfigDir:           configDir,
+		ConfigFile:          filepath.Join(configDir, fmt.Sprintf("%s-backup.conf", backupLabel)),
+		SecretsDir:          secretsDir,
+		SecretsFile:         secrets.GetSecretsFilePath(secretsDir, config.DefaultSecretsPrefix, backupLabel),
 	}
 }
 
@@ -150,6 +177,27 @@ func (p *Planner) loadConfig(plan *Plan) (*config.Config, error) {
 
 	p.log.Info("Configuration loaded successfully.")
 	return cfg, nil
+}
+
+func splitNonEmptyLines(value string) []string {
+	if value == "" {
+		return nil
+	}
+	lines := strings.Split(value, "\n")
+	result := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if line != "" {
+			result = append(result, line)
+		}
+	}
+	return result
+}
+
+func modeDisplay(remote bool) string {
+	if remote {
+		return "REMOTE"
+	}
+	return "LOCAL"
 }
 
 func (p *Planner) loadSecrets(plan *Plan) (*secrets.Secrets, error) {

--- a/internal/workflow/planner_test.go
+++ b/internal/workflow/planner_test.go
@@ -78,6 +78,12 @@ func TestPlannerBuild_BackupPlan(t *testing.T) {
 	if plan.PruneArgsDisplay != "" {
 		t.Fatalf("PruneArgsDisplay = %q, want empty", plan.PruneArgsDisplay)
 	}
+	if plan.BackupCommand != "duplicacy backup -stats -threads 4" {
+		t.Fatalf("BackupCommand = %q", plan.BackupCommand)
+	}
+	if plan.SnapshotCreateCommand == "" || plan.WorkDirCreateCommand == "" {
+		t.Fatalf("expected execution-ready commands, got %+v", plan)
+	}
 	if len(plan.Summary) == 0 {
 		t.Fatal("expected summary lines to be precomputed")
 	}
@@ -108,6 +114,12 @@ func TestPlannerBuild_FixPermsOnlyPlan(t *testing.T) {
 	}
 	if plan.ModeDisplay != "LOCAL" {
 		t.Fatalf("ModeDisplay = %q", plan.ModeDisplay)
+	}
+	if plan.OwnerGroup != owner+":"+group {
+		t.Fatalf("OwnerGroup = %q", plan.OwnerGroup)
+	}
+	if plan.FixPermsChownCommand == "" {
+		t.Fatal("expected fix-perms command to be precomputed")
 	}
 	if len(plan.Summary) != 5 {
 		t.Fatalf("summary lines = %d, want 5", len(plan.Summary))

--- a/internal/workflow/planner_test.go
+++ b/internal/workflow/planner_test.go
@@ -72,6 +72,15 @@ func TestPlannerBuild_BackupPlan(t *testing.T) {
 	if plan.BackupTarget != "/backups/homes" {
 		t.Fatalf("BackupTarget = %q", plan.BackupTarget)
 	}
+	if !plan.NeedsDuplicacySetup || !plan.NeedsSnapshot {
+		t.Fatalf("expected backup plan to need setup and snapshot: %+v", plan)
+	}
+	if plan.PruneArgsDisplay != "" {
+		t.Fatalf("PruneArgsDisplay = %q, want empty", plan.PruneArgsDisplay)
+	}
+	if len(plan.Summary) == 0 {
+		t.Fatal("expected summary lines to be precomputed")
+	}
 	if len(runner.Invocations) != 4 {
 		t.Fatalf("invocations = %d, want 4", len(runner.Invocations))
 	}
@@ -97,8 +106,10 @@ func TestPlannerBuild_FixPermsOnlyPlan(t *testing.T) {
 	if plan.OperationMode != "Fix permissions only" {
 		t.Fatalf("OperationMode = %q", plan.OperationMode)
 	}
-	lines := SummaryLines(plan)
-	if len(lines) != 4+1 {
-		t.Fatalf("summary lines = %d, want 5", len(lines))
+	if plan.ModeDisplay != "LOCAL" {
+		t.Fatalf("ModeDisplay = %q", plan.ModeDisplay)
+	}
+	if len(plan.Summary) != 5 {
+		t.Fatalf("summary lines = %d, want 5", len(plan.Summary))
 	}
 }

--- a/internal/workflow/presenter.go
+++ b/internal/workflow/presenter.go
@@ -1,0 +1,77 @@
+package workflow
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/duplicacy"
+	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/logger"
+)
+
+// Presenter owns operator-facing runtime output for the workflow execution
+// path. Keeping rendering here lets Executor focus on sequencing and policy.
+type Presenter struct {
+	meta Metadata
+	rt   Runtime
+	log  *logger.Logger
+}
+
+func NewPresenter(meta Metadata, rt Runtime, log *logger.Logger) *Presenter {
+	return &Presenter{meta: meta, rt: rt, log: log}
+}
+
+func (p *Presenter) PrintHeader(lockPath string) {
+	p.log.PrintSeparator()
+	p.log.Info("Backup script started - %s", p.rt.Now().Format("2006-01-02 15:04:05"))
+	p.log.PrintLine("Script", p.meta.ScriptName)
+	p.log.PrintLine("PID", fmt.Sprintf("%d", p.rt.Getpid()))
+	p.log.PrintLine("Lock Path", lockPath)
+	p.log.PrintSeparator()
+}
+
+func (p *Presenter) PrintSummary(plan *Plan) {
+	p.log.Info("Configuration Summary:")
+	for _, line := range plan.Summary {
+		p.log.PrintLine(line.Label, line.Value)
+	}
+}
+
+func (p *Presenter) PrintCommandOutput(stdout, stderr string) {
+	if stdout != "" {
+		for _, line := range strings.Split(strings.TrimRight(stdout, "\n"), "\n") {
+			if line != "" {
+				p.log.Info("%s", line)
+			}
+		}
+	}
+	if stderr != "" {
+		for _, line := range strings.Split(strings.TrimRight(stderr, "\n"), "\n") {
+			if line != "" {
+				p.log.Warn("%s", line)
+			}
+		}
+	}
+}
+
+func (p *Presenter) PrintPrunePreview(preview *duplicacy.PrunePreview, minTotalForPercent int) {
+	p.log.PrintLine("Preview Deletes", fmt.Sprintf("%d", preview.DeleteCount))
+	p.log.PrintLine("Preview Total Revs", fmt.Sprintf("%d", preview.TotalRevisions))
+	if preview.PercentEnforced {
+		p.log.PrintLine("Preview Delete %", fmt.Sprintf("%d", preview.DeletePercent))
+		return
+	}
+	p.log.PrintLine("Preview Delete %", fmt.Sprintf("<not enforced; total revisions unavailable or below %d>", minTotalForPercent))
+}
+
+func (p *Presenter) PrintCompletion(exitCode int) {
+	status := "SUCCESS"
+	if exitCode != 0 {
+		status = "FAILED"
+	}
+	p.log.PrintSeparator()
+	p.log.Info("Backup script completed:")
+	p.log.PrintLine("Result", p.log.FormatResult(status))
+	p.log.PrintLine("Code", fmt.Sprintf("%d", exitCode))
+	p.log.PrintLine("Timestamp", p.rt.Now().Format("2006-01-02 15:04:05"))
+	p.log.PrintSeparator()
+}

--- a/internal/workflow/presenter.go
+++ b/internal/workflow/presenter.go
@@ -22,7 +22,7 @@ func NewPresenter(meta Metadata, rt Runtime, log *logger.Logger) *Presenter {
 
 func (p *Presenter) PrintHeader(lockPath string) {
 	p.log.PrintSeparator()
-	p.log.Info("Backup script started - %s", p.rt.Now().Format("2006-01-02 15:04:05"))
+	p.log.Info("%s", statusLinef("Backup script started - %s", p.rt.Now().Format("2006-01-02 15:04:05")))
 	p.log.PrintLine("Script", p.meta.ScriptName)
 	p.log.PrintLine("PID", fmt.Sprintf("%d", p.rt.Getpid()))
 	p.log.PrintLine("Lock Path", lockPath)
@@ -30,7 +30,7 @@ func (p *Presenter) PrintHeader(lockPath string) {
 }
 
 func (p *Presenter) PrintSummary(plan *Plan) {
-	p.log.Info("Configuration Summary:")
+	p.log.Info("%s", statusLinef("Configuration Summary:"))
 	for _, line := range plan.Summary {
 		p.log.PrintLine(line.Label, line.Value)
 	}
@@ -69,7 +69,7 @@ func (p *Presenter) PrintCompletion(exitCode int) {
 		status = "FAILED"
 	}
 	p.log.PrintSeparator()
-	p.log.Info("Backup script completed:")
+	p.log.Info("%s", statusLinef("Backup script completed:"))
 	p.log.PrintLine("Result", p.log.FormatResult(status))
 	p.log.PrintLine("Code", fmt.Sprintf("%d", exitCode))
 	p.log.PrintLine("Timestamp", p.rt.Now().Format("2006-01-02 15:04:05"))

--- a/internal/workflow/prune.go
+++ b/internal/workflow/prune.go
@@ -1,0 +1,110 @@
+package workflow
+
+import (
+	"strings"
+
+	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/duplicacy"
+)
+
+func (e *Executor) runPrunePhase() error {
+	e.log.Info("%s", statusLinef("Starting prune phase."))
+
+	if e.plan.DryRun {
+		e.log.DryRun("%s", e.plan.ValidateRepoCommand)
+	} else {
+		if err := e.dup.ValidateRepo(); err != nil {
+			return err
+		}
+		e.log.Info("%s", statusLinef("Duplicacy repository validated."))
+	}
+
+	if e.plan.DryRun {
+		e.log.DryRun("%s", e.plan.PrunePreviewCommand)
+	}
+	preview, err := e.dup.SafePrunePreview(e.plan.PruneArgs, e.plan.SafePruneMinTotalForPercent)
+	if err != nil {
+		return err
+	}
+
+	e.logPrunePreviewOutput(preview)
+	if err := e.enforcePrunePreview(preview); err != nil {
+		return err
+	}
+
+	e.log.Info("%s", statusLinef("Starting policy prune."))
+	if e.plan.DryRun {
+		e.log.DryRun("%s", e.plan.PolicyPruneCommand)
+	} else {
+		stdout, stderr, err := e.dup.RunPrune(e.plan.PruneArgs)
+		e.view.PrintCommandOutput(stdout, stderr)
+		if err != nil {
+			return err
+		}
+	}
+	e.log.Info("%s", statusLinef("Policy prune completed."))
+
+	if e.plan.DeepPruneMode {
+		e.log.Warn("%s", statusLinef("Starting deep prune maintenance step: duplicacy prune -exhaustive -exclusive."))
+		if e.plan.DryRun {
+			e.log.DryRun("%s", e.plan.DeepPruneCommand)
+		} else {
+			stdout, stderr, err := e.dup.RunDeepPrune()
+			e.view.PrintCommandOutput(stdout, stderr)
+			if err != nil {
+				return err
+			}
+		}
+		e.log.Info("%s", statusLinef("Deep prune completed."))
+	}
+
+	e.log.Info("%s", statusLinef("Prune phase completed successfully."))
+	return nil
+}
+
+func (e *Executor) logPrunePreviewOutput(preview *duplicacy.PrunePreview) {
+	if preview.Output != "" {
+		for _, line := range strings.Split(preview.Output, "\n") {
+			if line != "" {
+				e.log.Info("[SAFE-PRUNE-PREVIEW] %s", line)
+			}
+		}
+	}
+	if preview.RevisionOutput != "" {
+		for _, line := range strings.Split(preview.RevisionOutput, "\n") {
+			if line != "" {
+				e.log.Info("[REVISION-LIST] %s", line)
+			}
+		}
+	}
+}
+
+func (e *Executor) enforcePrunePreview(preview *duplicacy.PrunePreview) error {
+	if preview.RevisionCountFailed {
+		if e.plan.ForcePrune {
+			e.log.Warn("%s", statusLinef("Revision count failed; proceeding because --force-prune was supplied (percentage threshold not enforced)."))
+		} else {
+			return NewMessageError("Revision count is required for safe prune but failed; use --force-prune to override.")
+		}
+	}
+
+	e.view.PrintPrunePreview(preview, e.plan.SafePruneMinTotalForPercent)
+
+	blocked := false
+	if preview.DeleteCount > e.plan.SafePruneMaxDeleteCount {
+		e.log.Error("%s", statusLinef("Safe prune preview exceeds delete count threshold: %d > %d.", preview.DeleteCount, e.plan.SafePruneMaxDeleteCount))
+		blocked = true
+	}
+	if preview.ExceedsPercent(e.plan.SafePruneMaxDeletePercent) {
+		e.log.Error("%s", statusLinef("Safe prune preview exceeds delete percentage threshold (%d of %d revisions > %d%%).", preview.DeleteCount, preview.TotalRevisions, e.plan.SafePruneMaxDeletePercent))
+		blocked = true
+	}
+	if blocked {
+		if e.plan.ForcePrune {
+			e.log.Warn("%s", statusLinef("Proceeding despite safe prune threshold breach because --force-prune was supplied."))
+		} else {
+			return NewMessageError("Refusing to continue because safe prune thresholds were exceeded.")
+		}
+	}
+
+	return nil
+}

--- a/internal/workflow/summary.go
+++ b/internal/workflow/summary.go
@@ -31,22 +31,22 @@ func OperationMode(req *Request) string {
 func SummaryLines(plan *Plan) []SummaryLine {
 	lines := []SummaryLine{{Label: "Operation Mode", Value: plan.OperationMode}}
 
-	if plan.Request.FixPermsOnly {
+	if plan.FixPermsOnly {
 		return append(lines,
 			SummaryLine{Label: "Destination", Value: plan.BackupTarget},
-			SummaryLine{Label: "Local Owner", Value: plan.Config.LocalOwner},
-			SummaryLine{Label: "Local Group", Value: plan.Config.LocalGroup},
-			SummaryLine{Label: "Dry Run", Value: fmt.Sprintf("%t", plan.Request.DryRun)},
+			SummaryLine{Label: "Local Owner", Value: plan.LocalOwner},
+			SummaryLine{Label: "Local Group", Value: plan.LocalGroup},
+			SummaryLine{Label: "Dry Run", Value: fmt.Sprintf("%t", plan.DryRun)},
 		)
 	}
 
 	lines = append(lines,
 		SummaryLine{Label: "Config File", Value: plan.ConfigFile},
 		SummaryLine{Label: "Backup Label", Value: plan.BackupLabel},
-		SummaryLine{Label: "Mode", Value: plan.ModeLabel()},
+		SummaryLine{Label: "Mode", Value: plan.ModeDisplay},
 		SummaryLine{Label: "Source", Value: plan.SnapshotSource},
 	)
-	if plan.Request.DoBackup {
+	if plan.DoBackup {
 		lines = append(lines, SummaryLine{Label: "Snapshot", Value: plan.RepositoryPath})
 	}
 	lines = append(lines,
@@ -54,42 +54,42 @@ func SummaryLines(plan *Plan) []SummaryLine {
 		SummaryLine{Label: "Destination", Value: plan.BackupTarget},
 	)
 
-	if plan.Config.Threads > 0 {
-		lines = append(lines, SummaryLine{Label: "Threads", Value: fmt.Sprintf("%d", plan.Config.Threads)})
+	if plan.Threads > 0 {
+		lines = append(lines, SummaryLine{Label: "Threads", Value: fmt.Sprintf("%d", plan.Threads)})
 	} else {
 		lines = append(lines, SummaryLine{Label: "Threads", Value: "<n/a>"})
 	}
 
-	if plan.Config.Filter != "" {
-		lines = append(lines, SummaryLine{Label: "Filter", Value: plan.Config.Filter})
+	if plan.Filter != "" {
+		lines = append(lines, SummaryLine{Label: "Filter", Value: plan.Filter})
 	} else {
 		lines = append(lines, SummaryLine{Label: "Filter", Value: "<none>"})
 	}
 
-	if plan.Config.Prune != "" {
-		lines = append(lines, SummaryLine{Label: "Prune Options", Value: plan.Config.Prune})
+	if plan.PruneOptions != "" {
+		lines = append(lines, SummaryLine{Label: "Prune Options", Value: plan.PruneOptions})
 	} else {
 		lines = append(lines, SummaryLine{Label: "Prune Options", Value: "<none>"})
 	}
 
 	lines = append(lines,
-		SummaryLine{Label: "Log Retention", Value: fmt.Sprintf("%d", plan.Config.LogRetentionDays)},
-		SummaryLine{Label: "Dry Run", Value: fmt.Sprintf("%t", plan.Request.DryRun)},
-		SummaryLine{Label: "Force Prune", Value: fmt.Sprintf("%t", plan.Request.ForcePrune)},
-		SummaryLine{Label: "Fix Perms", Value: fmt.Sprintf("%t", plan.Request.FixPerms)},
-		SummaryLine{Label: "Prune Max %", Value: fmt.Sprintf("%d", plan.Config.SafePruneMaxDeletePercent)},
-		SummaryLine{Label: "Prune Max Count", Value: fmt.Sprintf("%d", plan.Config.SafePruneMaxDeleteCount)},
-		SummaryLine{Label: "Prune Min Total Revs", Value: fmt.Sprintf("%d", plan.Config.SafePruneMinTotalForPercent)},
+		SummaryLine{Label: "Log Retention", Value: fmt.Sprintf("%d", plan.LogRetentionDays)},
+		SummaryLine{Label: "Dry Run", Value: fmt.Sprintf("%t", plan.DryRun)},
+		SummaryLine{Label: "Force Prune", Value: fmt.Sprintf("%t", plan.ForcePrune)},
+		SummaryLine{Label: "Fix Perms", Value: fmt.Sprintf("%t", plan.FixPerms)},
+		SummaryLine{Label: "Prune Max %", Value: fmt.Sprintf("%d", plan.SafePruneMaxDeletePercent)},
+		SummaryLine{Label: "Prune Max Count", Value: fmt.Sprintf("%d", plan.SafePruneMaxDeleteCount)},
+		SummaryLine{Label: "Prune Min Total Revs", Value: fmt.Sprintf("%d", plan.SafePruneMinTotalForPercent)},
 	)
 
-	if plan.Request.FixPerms {
+	if plan.FixPerms {
 		lines = append(lines,
-			SummaryLine{Label: "Local Owner", Value: plan.Config.LocalOwner},
-			SummaryLine{Label: "Local Group", Value: plan.Config.LocalGroup},
+			SummaryLine{Label: "Local Owner", Value: plan.LocalOwner},
+			SummaryLine{Label: "Local Group", Value: plan.LocalGroup},
 		)
 	}
 
-	if plan.Request.RemoteMode && plan.Secrets != nil {
+	if plan.RemoteMode && plan.Secrets != nil {
 		lines = append(lines,
 			SummaryLine{Label: "Secrets Dir", Value: plan.SecretsDir},
 			SummaryLine{Label: "Secrets File", Value: plan.SecretsFile},

--- a/internal/workflow/summary_test.go
+++ b/internal/workflow/summary_test.go
@@ -3,21 +3,15 @@ package workflow
 import (
 	"testing"
 
-	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/config"
 	"github.com/phillipmcmahon/synology-duplicacy-backup/internal/secrets"
 )
 
 func TestSummaryLines_FixPermsOnlyLayout(t *testing.T) {
 	plan := &Plan{
-		Request: &Request{
-			FixPerms:     true,
-			FixPermsOnly: true,
-			DryRun:       true,
-		},
-		Config: &config.Config{
-			LocalOwner: "backupuser",
-			LocalGroup: "users",
-		},
+		FixPermsOnly:  true,
+		DryRun:        true,
+		LocalOwner:    "backupuser",
+		LocalGroup:    "users",
 		BackupTarget:  "/backups/homes",
 		OperationMode: "Fix permissions only",
 	}
@@ -43,19 +37,13 @@ func TestSummaryLines_FixPermsOnlyLayout(t *testing.T) {
 
 func TestSummaryLines_RemoteIncludesSecrets(t *testing.T) {
 	plan := &Plan{
-		Request: &Request{
-			Mode:       "backup",
-			DoBackup:   true,
-			RemoteMode: true,
-		},
-		Config: &config.Config{
-			Destination:                 "/backups",
-			Threads:                     4,
-			LogRetentionDays:            30,
-			SafePruneMaxDeletePercent:   10,
-			SafePruneMaxDeleteCount:     25,
-			SafePruneMinTotalForPercent: 20,
-		},
+		DoBackup:                    true,
+		RemoteMode:                  true,
+		Threads:                     4,
+		LogRetentionDays:            30,
+		SafePruneMaxDeletePercent:   10,
+		SafePruneMaxDeleteCount:     25,
+		SafePruneMinTotalForPercent: 20,
 		Secrets: &secrets.Secrets{
 			StorjS3ID:     "1234567890123456789012345678",
 			StorjS3Secret: "12345678901234567890123456789012345678901234567890123",
@@ -68,6 +56,7 @@ func TestSummaryLines_RemoteIncludesSecrets(t *testing.T) {
 		ConfigFile:     "/config/homes-backup.conf",
 		SecretsDir:     "/root/.secrets",
 		SecretsFile:    "/root/.secrets/duplicacy-homes.env",
+		ModeDisplay:    "REMOTE",
 		OperationMode:  "Backup only",
 	}
 


### PR DESCRIPTION
## What changed

This follow-up finishes the workflow-boundary cleanup after the Request -> Plan -> Execute refactor.

Changes:
- tightens typed domain error translation and reduces fallback string handling
- standardizes operator-facing punctuation and runtime status messaging
- trims Executor by extracting prune, cleanup, and fix-perms execution helpers
- enriches Plan with more execution-ready values and precomputed command strings
- updates tests and docs to match the refined workflow boundaries

## Why

The main refactor is already in place. This PR focuses on the next layer of maintainability:
- clearer execution boundaries
- a richer plan contract
- more consistent operator output
- stronger tests around the workflow contract

## Validation

- go test ./...
- go vet ./...